### PR TITLE
New UpdateCheck via GitHub releases 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 SoMRandomizer/bin
 SoMRandomizer/obj
 SoMRandomizer.sln.DotSettings.user
+packages/

--- a/SoMRandomizer/App.config
+++ b/SoMRandomizer/App.config
@@ -1,6 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/SoMRandomizer/SoMRandomizer.csproj
+++ b/SoMRandomizer/SoMRandomizer.csproj
@@ -38,8 +38,37 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib" />
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.5\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.8.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=8.0.0.4, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.8.0.4\lib\net462\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -396,6 +425,7 @@
     <Compile Include="processing\common\InvisClearsSlow.cs" />
     <Compile Include="processing\common\OrbSwaps.cs" />
     <Compile Include="processing\vanillarando\VanillaRandoGenerator.cs" />
+    <Compile Include="util\UpdateCheck.cs" />
     <Compile Include="util\XyPos.cs" />
     <Compile Include="util\rng\DotNet110Random.cs" />
     <Compile Include="util\rng\HashcodeUtil.cs" />
@@ -445,6 +475,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
       <DesignTime>True</DesignTime>
     </Compile>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/SoMRandomizer/packages.config
+++ b/SoMRandomizer/packages.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net462" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
+  <package id="System.Memory" version="4.5.5" targetFramework="net462" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net462" />
+  <package id="System.Text.Encodings.Web" version="8.0.0" targetFramework="net462" />
+  <package id="System.Text.Json" version="8.0.4" targetFramework="net462" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net462" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net462" />
+</packages>

--- a/SoMRandomizer/util/UpdateCheck.cs
+++ b/SoMRandomizer/util/UpdateCheck.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
+using SoMRandomizer.processing.common;
+
+namespace SoMRandomizer.util
+{
+    public class UpdateCheck
+    {
+        private const string USER = "Moppu";
+        private const string REPO = "SecretOfManaRandomizer";
+        private static readonly string updateCheckUrl = $"https://api.github.com/repos/{USER}/{REPO}/releases/latest";
+        public static readonly string updateDownloadUrl = $"https://github.com/{USER}/{REPO}/releases/latest";
+
+        public static async Task<bool> checkForNewVersion()
+        {
+            // try to grab the latest release form GitHub and use the tag as latest version number
+            try
+            {
+                string responseBody;
+                // get the latest release
+                using (HttpClient client = new HttpClient())
+                {
+                    //GitHub API requires a UserAgent to be set
+                    client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Blerf", "1.0"));
+
+                    HttpResponseMessage response = await client.GetAsync(updateCheckUrl);
+                    response.EnsureSuccessStatusCode();
+                    responseBody = await response.Content.ReadAsStringAsync();
+                }
+
+                // parse the JSON response
+                using (JsonDocument doc = JsonDocument.Parse(responseBody))
+                {
+                    JsonElement root = doc.RootElement;
+                    string tagName = root.GetProperty("tag_name").GetString();
+                    if (string.IsNullOrEmpty(tagName))
+                    {
+                        return false;
+                    }
+
+                    // throw the version string into Version class to compare
+                    // note: the version string needs to have 2-4 numeric parts to work, just 1 won't parse (i.e. v2 would fail)
+                    Version currentVersion = new Version(RomGenerator.VERSION_NUMBER);
+                    Version latestVersion = new Version("2.0");
+                    return currentVersion < latestVersion;
+                }
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #7
Gets the latest version number by checking the tag on the latest release on GitHub via the GitHub API.
Moved update checking logic to a separate class ``UpdateCheck`` that also holds all relevant constants.
Adds ``System.Text.Json`` nuget package and add ``packages/`` to ``.gitignore``.