### PR TITLE
Replace mono check by try-catch in Program.cs

### DIFF
--- a/SoMRandomizer/Program.cs
+++ b/SoMRandomizer/Program.cs
@@ -59,9 +59,13 @@ namespace SoMRandomizer
             else
             {
                 // workaround for console under mono environment; need to call this for console to appear in windows env
-                if (!IsRunningOnMono())
+                try
                 {
                     AttachConsole(ATTACH_PARENT_PROCESS);
+                }
+                catch
+                {
+                    // ignore
                 }
 
                 // process commandline args for open world.  require all of these:
@@ -148,11 +152,6 @@ namespace SoMRandomizer
                     Console.WriteLine("exception encountered: " + ee.Message);
                 }
             }
-        }
-
-        private static bool IsRunningOnMono()
-        {
-            return Type.GetType("Mono.Runtime") != null;
         }
     }
 }


### PR DESCRIPTION
If we ever run this on core/.net6+, there will not be Mono, but the external DLL call will still fail on non-windows.

We could explicitly catch DllNotFound, however since we ignore the feature if it fails, it doesn't really matter. I'm open to changing it though.

Warning: i have not tested this change.