### PR TITLE
Add Tileset16 structure

### DIFF
--- a/SoMRandomizer/SoMRandomizer.csproj
+++ b/SoMRandomizer/SoMRandomizer.csproj
@@ -133,6 +133,7 @@
     <Compile Include="processing\common\structure\MapObject.cs" />
     <Compile Include="processing\common\structure\MapPaletteSet.cs" />
     <Compile Include="processing\common\structure\SnesColor.cs" />
+    <Compile Include="processing\common\structure\Tileset16.cs" />
     <Compile Include="processing\common\VanillaDoorUtil.cs" />
     <Compile Include="processing\common\VanillaMapUtil.cs" />
     <Compile Include="processing\common\VanillaPaletteUtil.cs" />

--- a/SoMRandomizer/processing/common/VanillaTilesetUtil.cs
+++ b/SoMRandomizer/processing/common/VanillaTilesetUtil.cs
@@ -1,6 +1,6 @@
 ﻿using SoMRandomizer.util;
 using System.Collections.Generic;
-using System.Linq;
+using SoMRandomizer.processing.common.structure;
 
 namespace SoMRandomizer.processing.common
 {
@@ -62,7 +62,7 @@ namespace SoMRandomizer.processing.common
             return tilesetRaw;
         }
 
-        public static List<short> DecodeTileset16(byte[] compressed)
+        public static Tileset16 DecodeTileset16(byte[] compressed)
         {
             BitPosition bitPosition = new BitPosition();
             ushort tileNum = 0;
@@ -70,101 +70,106 @@ namespace SoMRandomizer.processing.common
             bool hflip = false;
             bool altbg = true;
             byte pal = 4;
-            int counter = 0;
-            short[] uncompressedBuffer = new short[384 * 4];
-            while (counter < 384 * 4)
+            Tile16[] tiles = new Tile16[384];
+            for (int i = 0; i < 384; i++)
             {
-                ushort control1 = extractBits(compressed, 2, bitPosition);
-                switch (control1)
+                Tile8[] subTiles = new Tile8[4];    
+                for (int j = 0; j < 4; j++)
                 {
-                    case 0:
-                        uncompressedBuffer[counter] = (short)constructTileData(tileNum, vflip, hflip, altbg, pal);
-                        break;
-                    case 1:
-                        // 8bit add on 10bit value
-                        if ((tileNum & 0xFF) == 0xFF)
-                            tileNum -= 0xFF;
-                        else
-                            tileNum++;
-                        uncompressedBuffer[counter] = (short)constructTileData(tileNum, vflip, hflip, altbg, pal);
-                        break;
-                    case 2:
-                        // 8bit subtract on 10bit value
-                        if ((tileNum & 0xFF) == 0)
-                            tileNum += 0xFF;
-                        else
-                            tileNum--;
-                        uncompressedBuffer[counter] = (short)constructTileData(tileNum, vflip, hflip, altbg, pal);
-                        break;
-                    case 3:
-                        ushort nextBit = extractBits(compressed, 1, bitPosition);
-                        if (nextBit == 1)
-                        {
-                            ushort fourthBit = extractBits(compressed, 1, bitPosition);
-                            if (fourthBit == 1)
-                            {
-                                vflip = extractBits(compressed, 1, bitPosition) > 0;
-                                hflip = extractBits(compressed, 1, bitPosition) > 0;
-                                altbg = extractBits(compressed, 1, bitPosition) > 0;
-                                pal = (byte)extractBits(compressed, 3, bitPosition);
-                                tileNum = extractBits(compressed, 10, bitPosition);
-                                uncompressedBuffer[counter] = (short)constructTileData(tileNum, vflip, hflip, altbg, pal);
-                            }
+                    ushort control1 = extractBits(compressed, 2, bitPosition);
+                    switch (control1)
+                    {
+                        case 0:
+                            subTiles[j] = new Tile8(vflip, hflip, altbg, pal, tileNum);
+                            break;
+                        case 1:
+                            // 8bit add on 10bit value
+                            if ((tileNum & 0xFF) == 0xFF)
+                                tileNum -= 0xFF;
                             else
+                                tileNum++;
+                            subTiles[j] = new Tile8(vflip, hflip, altbg, pal, tileNum);
+                            break;
+                        case 2:
+                            // 8bit subtract on 10bit value
+                            if ((tileNum & 0xFF) == 0)
+                                tileNum += 0xFF;
+                            else
+                                tileNum--;
+                            subTiles[j] = new Tile8(vflip, hflip, altbg, pal, tileNum);
+                            break;
+                        case 3:
+                            ushort nextBit = extractBits(compressed, 1, bitPosition);
+                            if (nextBit == 1)
                             {
-                                ushort flagControlBit = extractBits(compressed, 1, bitPosition);
-                                if (flagControlBit == 1)
+                                ushort fourthBit = extractBits(compressed, 1, bitPosition);
+                                if (fourthBit == 1)
                                 {
-                                    ushort flags = extractBits(compressed, 3, bitPosition);
-                                    vflip = (flags & 0x04) > 0;
-                                    hflip = (flags & 0x02) > 0;
-                                    altbg = (flags & 0x01) > 0;
+                                    vflip = extractBits(compressed, 1, bitPosition) > 0;
+                                    hflip = extractBits(compressed, 1, bitPosition) > 0;
+                                    altbg = extractBits(compressed, 1, bitPosition) > 0;
+                                    pal = (byte)extractBits(compressed, 3, bitPosition);
+                                    tileNum = extractBits(compressed, 10, bitPosition);
+                                    subTiles[j] = new Tile8(vflip, hflip, altbg, pal, tileNum);
                                 }
                                 else
                                 {
-                                    ushort palette = extractBits(compressed, 3, bitPosition);
-                                    pal = (byte)palette;
+                                    ushort flagControlBit = extractBits(compressed, 1, bitPosition);
+                                    if (flagControlBit == 1)
+                                    {
+                                        ushort flags = extractBits(compressed, 3, bitPosition);
+                                        vflip = (flags & 0x04) > 0;
+                                        hflip = (flags & 0x02) > 0;
+                                        altbg = (flags & 0x01) > 0;
+                                    }
+                                    else
+                                    {
+                                        ushort palette = extractBits(compressed, 3, bitPosition);
+                                        pal = (byte)palette;
+                                    }
+
+                                    short add;
+                                    ushort sixBitSignedAdd = extractBits(compressed, 6, bitPosition);
+                                    // extend sign bits
+                                    if ((sixBitSignedAdd & 0x20) > 0)
+                                    {
+                                        sixBitSignedAdd |= 0xFFC0;
+                                        add = (short)sixBitSignedAdd;
+                                    }
+                                    else
+                                    {
+                                        add = (short)sixBitSignedAdd;
+                                    }
+
+                                    tileNum = (ushort)(tileNum + add);
+                                    subTiles[j] = new Tile8(vflip, hflip, altbg, pal, tileNum);
+                                }
+                            }
+                            else
+                            {
+                                short add;
+                                ushort sevenBitSignedAdd = extractBits(compressed, 7, bitPosition);
+                                // extend sign bits
+                                if ((sevenBitSignedAdd & 0x40) > 0)
+                                {
+                                    sevenBitSignedAdd |= 0xFF80;
+                                    add = (short)sevenBitSignedAdd;
+                                }
+                                else
+                                {
+                                    add = (short)sevenBitSignedAdd;
                                 }
 
-                                short add;
-                                ushort sixBitSignedAdd = extractBits(compressed, 6, bitPosition);
-                                // extend sign bits
-                                if ((sixBitSignedAdd & 0x20) > 0)
-                                {
-                                    sixBitSignedAdd |= 0xFFC0;
-                                    add = (short)sixBitSignedAdd;
-                                }
-                                else
-                                {
-                                    add = (short)sixBitSignedAdd;
-                                }
                                 tileNum = (ushort)(tileNum + add);
-                                uncompressedBuffer[counter] = (short)constructTileData(tileNum, vflip, hflip, altbg, pal);
+                                subTiles[j] = new Tile8(vflip, hflip, altbg, pal, tileNum);
                             }
-                        }
-                        else
-                        {
-                            short add;
-                            ushort sevenBitSignedAdd = extractBits(compressed, 7, bitPosition);
-                            // extend sign bits
-                            if ((sevenBitSignedAdd & 0x40) > 0)
-                            {
-                                sevenBitSignedAdd |= 0xFF80;
-                                add = (short)sevenBitSignedAdd;
-                            }
-                            else
-                            {
-                                add = (short)sevenBitSignedAdd;
-                            }
-                            tileNum = (ushort)(tileNum + add);
-                            uncompressedBuffer[counter] = (short)constructTileData(tileNum, vflip, hflip, altbg, pal);
-                        }
-                        break;
+                            break;
+                    }
                 }
 
-                counter++;
+                tiles[i] = new Tile16(subTiles);
             }
-            return uncompressedBuffer.ToList();
+            return new Tileset16(tiles);
         }
 
         private static void dropBits(byte[] compressed, int numBits, ushort data, BitPosition bitPosition)
@@ -187,146 +192,148 @@ namespace SoMRandomizer.processing.common
             }
         }
 
-        public static List<byte> EncodeTileset16(short[] uncompressed)
+        public static List<byte> EncodeTileset16(Tileset16 uncompressed)
         {
             byte[] compressedBuffer = new byte[10000];
             BitPosition bitPosition = new BitPosition();
-            int counter = 0;
             ushort tileNum = 0;
             bool vflip = false;
             bool hflip = false;
             bool altbg = true;
             byte pal = 4;
-            while (counter < 384 * 4)
+            for (int i = 0; i < 384; i++)
             {
-                ushort uncompressedData = (ushort)uncompressed[counter];
-                ushort thisTileNum = (ushort)(uncompressedData & 0x03FF);
-                bool thisVflip = (uncompressedData & 0x8000) > 0;
-                bool thisHflip = (uncompressedData & 0x4000) > 0;
-                bool thisAltBg = (uncompressedData & 0x2000) > 0;
-                byte thisPal = (byte)((uncompressedData & 0x1C00) >> 10);
-                // first tile - always do a full one
-                if (counter == 0)
+                Tile16 tile = uncompressed.Tiles[i];
+                for (int j = 0; j < 4; j++)
                 {
-                    dropBits(compressedBuffer, 4, 0x0F, bitPosition);
-                    dropBits(compressedBuffer, 16, uncompressedData, bitPosition);
-                }
-                else
-                {
-                    if (thisPal == pal && thisVflip == vflip && thisHflip == hflip && thisAltBg == altbg)
+                    Tile8 subtile = tile.Tiles[j];
+                    ushort uncompressedData = subtile.ToBinary();
+                    ushort thisTileNum = subtile.TileNum;
+                    bool thisVflip = subtile.VerticalFlip;
+                    bool thisHflip = subtile.HorizontalFlip;
+                    bool thisAltBg = subtile.AlternateRenderLayer;
+                    byte thisPal = subtile.Palette;
+                    // first tile - always do a full one
+                    if (i + j == 0 )
                     {
-                        if (thisTileNum == tileNum)
-                        {
-                            // 00
-                            dropBits(compressedBuffer, 2, 0, bitPosition);
-                        }
-                        else if ((thisTileNum) == ((tileNum + 1)))
-                        {
-                            // 01
-                            dropBits(compressedBuffer, 2, 1, bitPosition);
-                        }
-                        else if ((thisTileNum % 256) == ((tileNum - 1) % 256))
-                        {
-                            // 10
-                            dropBits(compressedBuffer, 2, 2, bitPosition);
-                        }
-                        // 7 bit range: -64 (1000000) to +63 (0111111)
-                        else if (thisTileNum < tileNum && tileNum - thisTileNum <= 64)
-                        {
-                            // 110
-                            dropBits(compressedBuffer, 3, 6, bitPosition);
-                            int diff = thisTileNum - tileNum;
-                            dropBits(compressedBuffer, 7, (ushort)diff, bitPosition);
-                        }
-                        else if (thisTileNum > tileNum && thisTileNum - tileNum <= 63)
-                        {
-                            // 110
-                            dropBits(compressedBuffer, 3, 6, bitPosition);
-                            int diff = thisTileNum - tileNum;
-                            dropBits(compressedBuffer, 7, (ushort)diff, bitPosition);
-                        }
-                        else
-                        {
-                            // full drop
-                            dropBits(compressedBuffer, 4, 0x0F, bitPosition);
-                            dropBits(compressedBuffer, 16, uncompressedData, bitPosition);
-                        }
-                    }
-                    else
-                    if (thisPal == pal)
-                    {
-                        // 6 bit range: -32 (100000) to +31 (011111)
-                        if (thisTileNum < tileNum && tileNum - thisTileNum <= 32)
-                        {
-                            // 1110
-                            dropBits(compressedBuffer, 4, 14, bitPosition);
-                            dropBits(compressedBuffer, 1, 1, bitPosition);
-                            dropBits(compressedBuffer, 1, (ushort)(thisVflip ? 1 : 0), bitPosition);
-                            dropBits(compressedBuffer, 1, (ushort)(thisHflip ? 1 : 0), bitPosition);
-                            dropBits(compressedBuffer, 1, (ushort)(thisAltBg ? 1 : 0), bitPosition);
-                            int diff = thisTileNum - tileNum;
-                            dropBits(compressedBuffer, 6, (ushort)diff, bitPosition);
-                        }
-                        else if (thisTileNum > tileNum && thisTileNum - tileNum <= 31)
-                        {
-                            // 1110
-                            dropBits(compressedBuffer, 4, 14, bitPosition);
-                            dropBits(compressedBuffer, 1, 1, bitPosition);
-                            dropBits(compressedBuffer, 1, (ushort)(thisVflip ? 1 : 0), bitPosition);
-                            dropBits(compressedBuffer, 1, (ushort)(thisHflip ? 1 : 0), bitPosition);
-                            dropBits(compressedBuffer, 1, (ushort)(thisAltBg ? 1 : 0), bitPosition);
-                            int diff = thisTileNum - tileNum;
-                            dropBits(compressedBuffer, 6, (ushort)diff, bitPosition);
-                        }
-                        else
-                        {
-                            // full drop
-                            dropBits(compressedBuffer, 4, 0x0F, bitPosition);
-                            dropBits(compressedBuffer, 16, uncompressedData, bitPosition);
-                        }
-                    }
-                    else if (thisVflip == vflip && thisHflip == hflip && thisAltBg == altbg)
-                    {
-                        // 6 bit range: -32 (100000) to +31 (011111)
-                        if (thisTileNum < tileNum && tileNum - thisTileNum <= 32)
-                        {
-                            // 1110
-                            dropBits(compressedBuffer, 4, 14, bitPosition);
-                            dropBits(compressedBuffer, 1, 0, bitPosition);
-                            dropBits(compressedBuffer, 3, (ushort)thisPal, bitPosition);
-                            int diff = thisTileNum - tileNum;
-                            dropBits(compressedBuffer, 6, (ushort)diff, bitPosition);
-                        }
-                        else if (thisTileNum > tileNum && thisTileNum - tileNum <= 31)
-                        {
-                            // 1110
-                            dropBits(compressedBuffer, 4, 14, bitPosition);
-                            dropBits(compressedBuffer, 1, 0, bitPosition);
-                            dropBits(compressedBuffer, 3, (ushort)thisPal, bitPosition);
-                            int diff = thisTileNum - tileNum;
-                            dropBits(compressedBuffer, 6, (ushort)diff, bitPosition);
-                        }
-                        else
-                        {
-                            // full drop
-                            dropBits(compressedBuffer, 4, 0x0F, bitPosition);
-                            dropBits(compressedBuffer, 16, uncompressedData, bitPosition);
-                        }
-                    }
-                    else
-                    {
-                        // full drop
                         dropBits(compressedBuffer, 4, 0x0F, bitPosition);
                         dropBits(compressedBuffer, 16, uncompressedData, bitPosition);
                     }
-                }
+                    else
+                    {
+                        if (thisPal == pal && thisVflip == vflip && thisHflip == hflip && thisAltBg == altbg)
+                        {
+                            if (thisTileNum == tileNum)
+                            {
+                                // 00
+                                dropBits(compressedBuffer, 2, 0, bitPosition);
+                            }
+                            else if ((thisTileNum) == ((tileNum + 1)))
+                            {
+                                // 01
+                                dropBits(compressedBuffer, 2, 1, bitPosition);
+                            }
+                            else if ((thisTileNum % 256) == ((tileNum - 1) % 256))
+                            {
+                                // 10
+                                dropBits(compressedBuffer, 2, 2, bitPosition);
+                            }
+                            // 7 bit range: -64 (1000000) to +63 (0111111)
+                            else if (thisTileNum < tileNum && tileNum - thisTileNum <= 64)
+                            {
+                                // 110
+                                dropBits(compressedBuffer, 3, 6, bitPosition);
+                                int diff = thisTileNum - tileNum;
+                                dropBits(compressedBuffer, 7, (ushort)diff, bitPosition);
+                            }
+                            else if (thisTileNum > tileNum && thisTileNum - tileNum <= 63)
+                            {
+                                // 110
+                                dropBits(compressedBuffer, 3, 6, bitPosition);
+                                int diff = thisTileNum - tileNum;
+                                dropBits(compressedBuffer, 7, (ushort)diff, bitPosition);
+                            }
+                            else
+                            {
+                                // full drop
+                                dropBits(compressedBuffer, 4, 0x0F, bitPosition);
+                                dropBits(compressedBuffer, 16, uncompressedData, bitPosition);
+                            }
+                        }
+                        else if (thisPal == pal)
+                        {
+                            // 6 bit range: -32 (100000) to +31 (011111)
+                            if (thisTileNum < tileNum && tileNum - thisTileNum <= 32)
+                            {
+                                // 1110
+                                dropBits(compressedBuffer, 4, 14, bitPosition);
+                                dropBits(compressedBuffer, 1, 1, bitPosition);
+                                dropBits(compressedBuffer, 1, (ushort)(thisVflip ? 1 : 0), bitPosition);
+                                dropBits(compressedBuffer, 1, (ushort)(thisHflip ? 1 : 0), bitPosition);
+                                dropBits(compressedBuffer, 1, (ushort)(thisAltBg ? 1 : 0), bitPosition);
+                                int diff = thisTileNum - tileNum;
+                                dropBits(compressedBuffer, 6, (ushort)diff, bitPosition);
+                            }
+                            else if (thisTileNum > tileNum && thisTileNum - tileNum <= 31)
+                            {
+                                // 1110
+                                dropBits(compressedBuffer, 4, 14, bitPosition);
+                                dropBits(compressedBuffer, 1, 1, bitPosition);
+                                dropBits(compressedBuffer, 1, (ushort)(thisVflip ? 1 : 0), bitPosition);
+                                dropBits(compressedBuffer, 1, (ushort)(thisHflip ? 1 : 0), bitPosition);
+                                dropBits(compressedBuffer, 1, (ushort)(thisAltBg ? 1 : 0), bitPosition);
+                                int diff = thisTileNum - tileNum;
+                                dropBits(compressedBuffer, 6, (ushort)diff, bitPosition);
+                            }
+                            else
+                            {
+                                // full drop
+                                dropBits(compressedBuffer, 4, 0x0F, bitPosition);
+                                dropBits(compressedBuffer, 16, uncompressedData, bitPosition);
+                            }
+                        }
+                        else if (thisVflip == vflip && thisHflip == hflip && thisAltBg == altbg)
+                        {
+                            // 6 bit range: -32 (100000) to +31 (011111)
+                            if (thisTileNum < tileNum && tileNum - thisTileNum <= 32)
+                            {
+                                // 1110
+                                dropBits(compressedBuffer, 4, 14, bitPosition);
+                                dropBits(compressedBuffer, 1, 0, bitPosition);
+                                dropBits(compressedBuffer, 3, (ushort)thisPal, bitPosition);
+                                int diff = thisTileNum - tileNum;
+                                dropBits(compressedBuffer, 6, (ushort)diff, bitPosition);
+                            }
+                            else if (thisTileNum > tileNum && thisTileNum - tileNum <= 31)
+                            {
+                                // 1110
+                                dropBits(compressedBuffer, 4, 14, bitPosition);
+                                dropBits(compressedBuffer, 1, 0, bitPosition);
+                                dropBits(compressedBuffer, 3, (ushort)thisPal, bitPosition);
+                                int diff = thisTileNum - tileNum;
+                                dropBits(compressedBuffer, 6, (ushort)diff, bitPosition);
+                            }
+                            else
+                            {
+                                // full drop
+                                dropBits(compressedBuffer, 4, 0x0F, bitPosition);
+                                dropBits(compressedBuffer, 16, uncompressedData, bitPosition);
+                            }
+                        }
+                        else
+                        {
+                            // full drop
+                            dropBits(compressedBuffer, 4, 0x0F, bitPosition);
+                            dropBits(compressedBuffer, 16, uncompressedData, bitPosition);
+                        }
+                    }
 
-                tileNum = thisTileNum;
-                pal = thisPal;
-                vflip = thisVflip;
-                hflip = thisHflip;
-                altbg = thisAltBg;
-                counter++;
+                    tileNum = thisTileNum;
+                    pal = thisPal;
+                    vflip = thisVflip;
+                    hflip = thisHflip;
+                    altbg = thisAltBg;
+                }
             }
 
             List<byte> output = new List<byte>();

--- a/SoMRandomizer/processing/common/VanillaTilesetUtil.cs
+++ b/SoMRandomizer/processing/common/VanillaTilesetUtil.cs
@@ -73,7 +73,7 @@ namespace SoMRandomizer.processing.common
             Tile16[] tiles = new Tile16[384];
             for (int i = 0; i < 384; i++)
             {
-                Tile8[] subTiles = new Tile8[4];    
+                Tile8[] subTiles = new Tile8[4];
                 for (int j = 0; j < 4; j++)
                 {
                     ushort control1 = extractBits(compressed, 2, bitPosition);

--- a/SoMRandomizer/processing/common/structure/Tileset16.cs
+++ b/SoMRandomizer/processing/common/structure/Tileset16.cs
@@ -40,12 +40,12 @@ namespace SoMRandomizer.processing.common.structure
             get
             {
                 if (index < 0 || index >= LAYER_SIZE) throw new InvalidOperationException("index has to be between 0 and 192");
-                return Tiles[foreground ? 192 : 0 + index];
+                return Tiles[foreground ? LAYER_SIZE : 0 + index];
             }
             set
             {
                 if (index < 0 || index >= LAYER_SIZE) throw new InvalidOperationException("index has to be between 0 and 192");
-                Tiles[foreground ? 192 : 0 + index] = value;
+                Tiles[foreground ? LAYER_SIZE : 0 + index] = value;
             }
         }
 

--- a/SoMRandomizer/processing/common/structure/Tileset16.cs
+++ b/SoMRandomizer/processing/common/structure/Tileset16.cs
@@ -1,0 +1,166 @@
+using System;
+
+namespace SoMRandomizer.processing.common.structure
+{
+    /// <summary>
+    /// Tileset containing 384 16x16 Tiles - 192 background and 192 foreground.
+    /// </summary>
+    public class Tileset16
+    {
+        const int LAYER_SIZE = 192;
+        public Tile16[] Tiles { get; set; }
+        
+        /// <summary>
+        /// for directly indexing tiles
+        /// </summary>
+        /// <param name="index"></param>
+        /// <exception cref="InvalidOperationException"></exception>
+        public Tile16 this[int index]
+        {
+            get
+            {
+                if (index < 0 || index >= 384) throw new InvalidOperationException("index has to be between 0 and 384");
+                return Tiles[index];
+            }
+            set
+            {
+                if (index < 0 || index >= 384) throw new InvalidOperationException("index has to be between 0 and 384");
+                Tiles[index] = value;
+            }
+        }
+        
+        /// ToDo: do we even need/want this
+        /// <summary>
+        /// for indexing into foreground/background layer directly
+        /// </summary>
+        /// <param name="foreground">if true, 192 will be added to <paramref name="index"/> for the actual index into <see cref="Tiles"/></param>
+        /// <param name="index">index into the layer</param>
+        public Tile16 this[bool foreground, int index]
+        {
+            get
+            {
+                if (index < 0 || index >= LAYER_SIZE) throw new InvalidOperationException("index has to be between 0 and 192");
+                return Tiles[foreground ? 192 : 0 + index];
+            }
+            set
+            {
+                if (index < 0 || index >= LAYER_SIZE) throw new InvalidOperationException("index has to be between 0 and 192");
+                Tiles[foreground ? 192 : 0 + index] = value;
+            }
+        }
+
+        public Tileset16(Tile16[] tiles)
+        {
+            if (tiles.Length != 384)
+                throw new ArgumentException("Tileset16 has to have 384 tiles", nameof(tiles));
+            Tiles = tiles;
+        }
+    }
+    
+    /// <summary>
+    /// 16x16 Tile constructed by 4 8x8 Tiles
+    /// </summary>
+    /// <seealso cref="Tile8"/>
+    public class Tile16
+    {
+        public Tile16(Tile8[] tiles)
+        {
+            if (tiles.Length != 4)
+                throw new ArgumentException("Tile16 has to have 4 Tile8s", nameof(tiles));
+            Tiles = tiles;
+        }
+        
+        public Tile8 this[int index]
+        {
+            get => Tiles[index];
+            set => Tiles[index] = value;
+        }
+        
+        public Tile8[] Tiles { get; set; }
+    }
+    
+    /// <summary>
+    /// 8x8 Tile
+    /// </summary>
+    public class Tile8
+    {
+        /// <summary>
+        /// Vertical Flip Flag
+        /// </summary>
+        public bool VerticalFlip { get; set; }
+        /// <summary>
+        /// Horizontal Flip Flag
+        /// </summary>
+        public bool HorizontalFlip { get; set; }
+        /// <summary>
+        /// Alternate Render Layer Flag
+        /// </summary>
+        public bool AlternateRenderLayer { get; set; }
+        private byte _palette { get; set; }
+        /// <summary>
+        /// 3-bit Palette ID
+        /// </summary>
+        public byte Palette
+        {
+            get => _palette;
+            //limit to 3-bit
+            set => _palette = (byte)(value & 0x7);
+        }
+
+        private ushort _tileNum;
+        /// <summary>
+        /// 10-bit Tileset8 Index
+        /// </summary>
+        public ushort TileNum
+        {
+            get => _tileNum;
+            //limit to 10-bit
+            set => _tileNum = (ushort)(value & 0x3FF);
+        }
+
+        public Tile8(bool verticalFlip = false, bool horizontalFlip = false, bool alternateRenderLayer = false, byte palette = 0, ushort tileNum = 0)
+        {
+            VerticalFlip = verticalFlip;
+            HorizontalFlip = horizontalFlip;
+            AlternateRenderLayer = alternateRenderLayer;
+            Palette = palette;
+            TileNum = tileNum;
+        }
+
+        /// <summary>
+        /// convert to raw 16-bit value of the 8x8 Tile
+        /// in the format of
+        /// [VHAPPPTTTTTTTTT]
+        /// V is a vertical flip flag
+        /// H is a horizontal flip flag
+        /// A is an alternate render layer flag (causes some tiles to show in front of or behind sprites)
+        /// PPP is a 3-bit palette id
+        /// TTTTTTTTTT is a 10-bit tile index into the associated tileset8
+        /// </summary>
+        public ushort ToBinary()
+        {
+            return (ushort)(
+                (VerticalFlip ? 1<<15 : 0) |
+                (HorizontalFlip ? 1<<14 : 0) |
+                (AlternateRenderLayer ? 1<<13 : 0) |
+                (Palette << 10) |
+                TileNum);
+        }
+
+        /// <summary>
+        /// Decode into <see cref="Tile8"/> structure from the raw binary value
+        /// </summary>
+        /// <param name="data">binary value</param>
+        /// <returns>decoded <see cref="Tile8"/></returns>
+        /// <seealso cref="ToBinary"/>
+        public static Tile8 FromBinary(ushort data)
+        {
+            return new Tile8(
+                (data & 0x8000) != 0,
+                (data & 0x4000) != 0,
+                (data & 0x2000) != 0,
+                (byte)((data >> 10) & 0x7),
+                (ushort)(data & 0x3FF));
+        }
+    }
+}

--- a/SoMRandomizer/processing/hacks/ancientcave/AcIslandTilesetChanges.cs
+++ b/SoMRandomizer/processing/hacks/ancientcave/AcIslandTilesetChanges.cs
@@ -2,6 +2,7 @@
 using SoMRandomizer.processing.common;
 using SoMRandomizer.util;
 using System.Collections.Generic;
+using SoMRandomizer.processing.common.structure;
 
 namespace SoMRandomizer.processing.hacks.ancientcave
 {
@@ -21,7 +22,7 @@ namespace SoMRandomizer.processing.hacks.ancientcave
         {
             int tilesetNum = 5;
             byte[] tilesetRaw = VanillaTilesetUtil.getCompressedVanillaTileset16(origRom, tilesetNum);
-            List<short> tilesetDecomp = VanillaTilesetUtil.DecodeTileset16(tilesetRaw);
+            Tileset16 tilesetDecomp = VanillaTilesetUtil.DecodeTileset16(tilesetRaw);
 
             // all numbers * 4
             // on layer2 (+192) 111, 119-127, 135-143, 159, 174-175, 186-191
@@ -33,82 +34,80 @@ namespace SoMRandomizer.processing.hacks.ancientcave
                     for (int j = 0; j < 4; j++)
                     {
                         // FG layer
-                        tilesetDecomp[192 * 4 + ii * 4 + j] |= 0x2000;
+                        tilesetDecomp[192 + ii][j].AlternateRenderLayer = true;
                     }
                 }
             }
 
-            // MOPPLE: it might be nice to have a structure for what's represented by these Tileset16 values, instead
-            // of just shoving bits onto it here (16 bit VHAPPPTTTTTTTTT)
 
             // huts on layer 1
             // palette 4
             // 0x4000 for hflip
-            tilesetDecomp[118 * 4] = 863 + (4 << 10);
-            tilesetDecomp[118 * 4 + 1] = 48 + (4 << 10);
-            tilesetDecomp[118 * 4 + 2] = 863 + (4 << 10);
-            tilesetDecomp[118 * 4 + 3] = 64 + (4 << 10);
+            tilesetDecomp[118][0] = new Tile8(tileNum: 863, palette: 4);
+            tilesetDecomp[118][1] = new Tile8(tileNum: 48, palette: 4);
+            tilesetDecomp[118][2] = new Tile8(tileNum: 863, palette: 4);
+            tilesetDecomp[118][3] = new Tile8(tileNum: 64, palette: 4);
 
-            tilesetDecomp[119 * 4] = 863 + (4 << 10);
-            tilesetDecomp[119 * 4 + 1] = 863 + (4 << 10);
-            tilesetDecomp[119 * 4 + 2] = 863 + (4 << 10);
-            tilesetDecomp[119 * 4 + 3] = 2 + (4 << 10);
+            tilesetDecomp[119][0] = new Tile8(tileNum: 863, palette: 4);
+            tilesetDecomp[119][1] = new Tile8(tileNum: 863, palette: 4);
+            tilesetDecomp[119][2] = new Tile8(tileNum: 863, palette: 4);
+            tilesetDecomp[119][3] = new Tile8(tileNum: 2, palette: 4);
 
-            tilesetDecomp[120 * 4] = 863 + (4 << 10);
-            tilesetDecomp[120 * 4 + 1] = 863 + (4 << 10);
-            tilesetDecomp[120 * 4 + 2] = 3 + (4 << 10);
-            tilesetDecomp[120 * 4 + 3] = (3 + (4 << 10)) | 0x4000;
+            tilesetDecomp[120][0] = new Tile8(tileNum: 863, palette: 4);
+            tilesetDecomp[120][1] = new Tile8(tileNum: 863, palette: 4);
+            tilesetDecomp[120][2] = new Tile8(tileNum: 3, palette: 4);
+            tilesetDecomp[120][3] = new Tile8(tileNum: 3, palette: 4, horizontalFlip: true);
 
-            tilesetDecomp[121 * 4] = 863 + (4 << 10);
-            tilesetDecomp[121 * 4 + 1] = 863 + (4 << 10);
-            tilesetDecomp[121 * 4 + 2] = (2 + (4 << 10)) | 0x4000;
-            tilesetDecomp[121 * 4 + 3] = 863 + (4 << 10);
+            tilesetDecomp[121][0] = new Tile8(tileNum: 863, palette: 4);
+            tilesetDecomp[121][1] = new Tile8(tileNum: 863, palette: 4);
+            tilesetDecomp[121][2] = new Tile8(tileNum: 2, palette: 4, horizontalFlip: true);
+            tilesetDecomp[121][3] = new Tile8(tileNum: 863, palette: 4);
 
-            tilesetDecomp[122 * 4] = (48 + (4 << 10)) | 0x4000;
-            tilesetDecomp[122 * 4 + 1] = 863 + (4 << 10);
-            tilesetDecomp[122 * 4 + 2] = (64 + (4 << 10)) | 0x4000;
-            tilesetDecomp[122 * 4 + 3] = 863 + (4 << 10);
+            tilesetDecomp[122][0] = new Tile8(tileNum: 48, palette: 4, horizontalFlip: true);
+            tilesetDecomp[122][1] = new Tile8(tileNum: 863, palette: 4);
+            tilesetDecomp[122][2] = new Tile8(tileNum: 64, palette: 4, horizontalFlip: true);
+            tilesetDecomp[122][3] = new Tile8(tileNum: 863, palette: 4);
 
 
-            tilesetDecomp[134 * 4] = 863 + (4 << 10);
-            tilesetDecomp[134 * 4 + 1] = 863 + (4 << 10);
-            tilesetDecomp[134 * 4 + 2] = 863 + (4 << 10);
-            tilesetDecomp[134 * 4 + 3] = 32 + (4 << 10);
+            tilesetDecomp[134][0] = new Tile8(tileNum: 863, palette: 4);
+            tilesetDecomp[134][1] = new Tile8(tileNum: 863, palette: 4);
+            tilesetDecomp[134][2] = new Tile8(tileNum: 863, palette: 4);
+            tilesetDecomp[134][3] = new Tile8(tileNum: 32, palette: 4);
 
-            tilesetDecomp[135 * 4] = 17 + (4 << 10);
-            tilesetDecomp[135 * 4 + 1] = 18 + (4 << 10);
-            tilesetDecomp[135 * 4 + 2] = 33 + (4 << 10);
-            tilesetDecomp[135 * 4 + 3] = 34 + (4 << 10);
+            tilesetDecomp[135][0] = new Tile8(tileNum: 17, palette: 4);
+            tilesetDecomp[135][1] = new Tile8(tileNum: 18, palette: 4);
+            tilesetDecomp[135][2] = new Tile8(tileNum: 33, palette: 4);
+            tilesetDecomp[135][3] = new Tile8(tileNum: 34, palette: 4);
 
-            tilesetDecomp[136 * 4] = 19 + (4 << 10);
-            tilesetDecomp[136 * 4 + 1] = (19 + (4 << 10)) | 0x4000;
-            tilesetDecomp[136 * 4 + 2] = 35 + (4 << 10);
-            tilesetDecomp[136 * 4 + 3] = (35 + (4 << 10)) | 0x4000;
+            tilesetDecomp[136][0] = new Tile8(tileNum: 19, palette: 4);
+            tilesetDecomp[136][1] = new Tile8(tileNum: 19, palette: 4, horizontalFlip: true);
+            tilesetDecomp[136][2] = new Tile8(tileNum: 35, palette: 4);
+            tilesetDecomp[136][3] = new Tile8(tileNum: 35, palette: 4, horizontalFlip: true);
 
-            tilesetDecomp[137 * 4] = (18 + (4 << 10)) | 0x4000;
-            tilesetDecomp[137 * 4 + 1] = (17 + (4 << 10)) | 0x4000;
-            tilesetDecomp[137 * 4 + 2] = (34 + (4 << 10)) | 0x4000;
-            tilesetDecomp[137 * 4 + 3] = (33 + (4 << 10)) | 0x4000;
+            tilesetDecomp[137][0] = new Tile8(tileNum: 18, palette: 4, horizontalFlip: true);
+            tilesetDecomp[137][1] = new Tile8(tileNum: 17, palette: 4, horizontalFlip: true);
+            tilesetDecomp[137][2] = new Tile8(tileNum: 34, palette: 4, horizontalFlip: true);
+            tilesetDecomp[137][3] = new Tile8(tileNum: 33, palette: 4, horizontalFlip: true);
 
-            tilesetDecomp[138 * 4] = 863 + (4 << 10);
-            tilesetDecomp[138 * 4 + 1] = 863 + (4 << 10);
-            tilesetDecomp[138 * 4 + 2] = (32 + (4 << 10)) | 0x4000;
-            tilesetDecomp[138 * 4 + 3] = 863 + (4 << 10);
+            tilesetDecomp[138][0] = new Tile8(tileNum: 863, palette: 4);
+            tilesetDecomp[138][1] = new Tile8(tileNum: 863, palette: 4);
+            tilesetDecomp[138][2] = new Tile8(tileNum: 32, palette: 4, horizontalFlip: true);
+            tilesetDecomp[138][3] = new Tile8(tileNum: 863, palette: 4);
 
             // grass on layer 2
-            tilesetDecomp[192 * 4 + 77 * 4] = 512 + (2 << 10);
-            tilesetDecomp[192 * 4 + 77 * 4 + 1] = 513 + (2 << 10);
-            tilesetDecomp[192 * 4 + 77 * 4 + 2] = 528 + (2 << 10);
-            tilesetDecomp[192 * 4 + 77 * 4 + 3] = 529 + (2 << 10);
+            tilesetDecomp[192 + 77][0] = new Tile8(tileNum: 512, palette: 2);
+            tilesetDecomp[192 + 77][1] = new Tile8(tileNum: 513, palette: 2);
+            tilesetDecomp[192 + 77][2] = new Tile8(tileNum: 528, palette: 2);
+            tilesetDecomp[192 + 77][3] = new Tile8(tileNum: 529, palette: 2);
 
             // fire on layer1
-            tilesetDecomp[143 * 4] = 874 + (6 << 10);
-            tilesetDecomp[143 * 4 + 1] = 875 + (6 << 10);
-            tilesetDecomp[143 * 4 + 2] = 876 + (6 << 10);
-            tilesetDecomp[143 * 4 + 3] = 877 + (6 << 10);
+            tilesetDecomp[143][0] = new Tile8(tileNum: 874, palette: 6);
+            tilesetDecomp[143][1] = new Tile8(tileNum: 875, palette: 6);
+            tilesetDecomp[143][2] = new Tile8(tileNum: 876, palette: 6);
+            tilesetDecomp[143][3] = new Tile8(tileNum: 877, palette: 6);
 
             // write tileset back to a new spot
-            List<byte> tilesetCompressed = VanillaTilesetUtil.EncodeTileset16(tilesetDecomp.ToArray());
+            List<byte> tilesetCompressed = VanillaTilesetUtil.EncodeTileset16(tilesetDecomp);
             int tilesetLocation = context.workingOffset;
             for (int i = 0; i < tilesetCompressed.Count; i++)
             {


### PR DESCRIPTION
resolves #10

Adds Tileset16 containing 384 Tile16s each containing 4 Tile8s.
Tile8 contains fields according to the binary format described in the issue as well as some helper functions to convert to/from the binary format.
Tileset16 implements an indexer  to directly index into the Tile16s and Tile16 implements an indexer to directly index into the Tile8s.
Tileset16 also implements an additional indexer to index based on foreground/background layer (no clue if we actually want/need this).

Tested by matching ROM output with and without changes on open world and ancient cave default settings
