### PR TITLE
CI: add build action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: microsoft/setup-msbuild@v2
+      - name: Install Dependencies
+        run: |
+          nuget restore
+      - name: Build Debug
+        run: |
+          msbuild
+          ls SoMRandomizer\bin\Debug
+      - name: Store
+        uses: actions/upload-artifact@v4
+        with:
+          name: SecretOfManaRandomizer-Debug
+          path: SomRandomizer/bin/Debug/SoMRandomizer.*
+          if-no-files-found: error
+          compression-level: 9
+          retention-days: 7


### PR DESCRIPTION
This stores build artifacts for easy testing and also doubles as simple build test  (i.e. shows up as error in a PR if the commits forgot to include a file or a merge conflict wasn't resolved properly).