### PR TITLE
Fix garbage next to seed hash display

### DIFF
--- a/SoMRandomizer/processing/hacks/openworld/TitleMenuSeedHashDisplay.cs
+++ b/SoMRandomizer/processing/hacks/openworld/TitleMenuSeedHashDisplay.cs
@@ -39,7 +39,6 @@ namespace SoMRandomizer.processing.hacks.openworld
             List<byte> introMenuReplacement = VanillaEventUtil.getBytes("Secret of Mana Open World v" + RomGenerator.VERSION_NUMBER + "\n\n" + "Seed: " + seedShortened + "\n\n" + "Hash check: " + hashString + "\n\nEnjoy", -1);
             // 0x33F0 is the "WELCOME TO SECRET OF MANA" text
             // through 348B
-            // MOPPLE: this sometimes leaves some trailing garbage on the right side, and i'm not sure why
             int introMenuSize = 0x348B - 0x33F0 + 1;
             int srcI = 0;
             for (int i = 0; i < introMenuSize; i++)
@@ -54,7 +53,7 @@ namespace SoMRandomizer.processing.hacks.openworld
                 }
                 else
                 {
-                    outRom[0x33F0 + i] = 0;
+                    outRom[0x33F0 + i] = (byte)(i == introMenuSize - 1 ? 0 : 0x80);
                 }
                 srcI++;
             }


### PR DESCRIPTION
Filling available memory with spaces (0x80) seems to fix the issue where there is garbage in the title screen next to the seed hash display... at least from what I can tell.
There is probably a better way to fix this but ¯\\_(ツ)_/¯