### PR TITLE
Fix some inaccurate access logic

### DIFF
--- a/SoMRandomizer/processing/openworld/randomization/OpenWorldHints.cs
+++ b/SoMRandomizer/processing/openworld/randomization/OpenWorldHints.cs
@@ -32,9 +32,9 @@ namespace SoMRandomizer.processing.openworld.randomization
             bool giveMoreGrandPalaceHints = goal == OpenWorldGoalProcessor.GOAL_MANABEAST && !context.workingData.getBool(OpenWorldGoalProcessor.MANA_FORT_ACCESSIBLE_INDICATOR);
             bool girlSpellsExist = context.workingData.getBool(OpenWorldClassSelection.GIRL_MAGIC_EXISTS);
             bool spriteSpellsExist = context.workingData.getBool(OpenWorldClassSelection.SPRITE_MAGIC_EXISTS);
-            List<string> grandPalaceDependencies = new List<string>();
+            List<string> grandPalaceBossDependencies = new List<string>();
             List<string> manafortDependencies = new List<string>();
-            OpenWorldLocations.populateDependencies(settings, context, grandPalaceDependencies, manafortDependencies);
+            OpenWorldLocations.populateDependencies(settings, context, grandPalaceBossDependencies, manafortDependencies);
 
             List<string> importantPrizes = new string[] { "boy", "boy", "girl", "girl", "sprite", "sprite", "whip", "axe", "sword" }.ToList();
             if (goal == OpenWorldGoalProcessor.GOAL_MTR)
@@ -290,7 +290,7 @@ namespace SoMRandomizer.processing.openworld.randomization
                             eleNum = (byte)(0x81 + (r.Next() % 8));
                         }
                         string dependency = SomVanillaValues.elementOrbByteToName(eleNum, false) + " spells";
-                        if (!grandPalaceDependencies.Contains(dependency))
+                        if (!grandPalaceBossDependencies.Contains(dependency))
                         {
                             string hintPhrase = "Not needed for grand palace: " + SomVanillaValues.elementOrbByteToName(eleNum, false);
                             hintPhrase = VanillaEventUtil.wordWrapText(hintPhrase);

--- a/SoMRandomizer/processing/openworld/randomization/OpenWorldLocations.cs
+++ b/SoMRandomizer/processing/openworld/randomization/OpenWorldLocations.cs
@@ -17,6 +17,8 @@ namespace SoMRandomizer.processing.openworld.randomization
         public const string DEPENDENCY_GIRL_SPELLS = "girlCaster";
         public const string DEPENDENCY_SPRITE_SPELLS = "spriteCaster";
         public const string DEPENDENCY_ELINEE_ENTRY = "elinee"; // whip and cutting weapon or axe
+        public const string DEPENDENCY_CUTTING_WEAPON = "cuttingWeapon";
+        public const string DEPENDENCY_MATANGO_ENTRY = "matango";
 
         public static List<PrizeLocation> getForSelectedOptions(RandoSettings settings, RandoContext context)
         {
@@ -28,7 +30,7 @@ namespace SoMRandomizer.processing.openworld.randomization
             bool anyCharsAdded = !context.workingData.getBool(OpenWorldCharacterSelection.START_SOLO);
             Dictionary<int, byte> crystalOrbColorMap = ElementSwaps.getCrystalOrbElementMap(context);
 
-            List<string> grandPalaceDependencies = new List<string>();
+            List<string> grandPalaceBossDependencies = new List<string>();
             List<string> manafortDependencies = new List<string>();
 
             string _earthPalaceElement = (!anySpellTriggers) ? "no" : SomVanillaValues.elementOrbByteToName(crystalOrbColorMap[ElementSwaps.ORBMAP_EARTHPALACE], false);
@@ -43,19 +45,19 @@ namespace SoMRandomizer.processing.openworld.randomization
                 _upperLandElement = (!anySpellTriggers) ? "no" : SomVanillaValues.elementOrbByteToName(crystalOrbColorMap[ElementSwaps.ORBMAP_UPPERLAND], false);
             }
 
-            populateDependencies(settings, context, grandPalaceDependencies, manafortDependencies);
+            populateDependencies(settings, context, grandPalaceBossDependencies, manafortDependencies);
 
             List<PrizeLocation> allLocations = new List<PrizeLocation>();
 
             // all event numbers here (second param to PrizeLocation) should correspond to ones created in PrizeEvents, containing the OPENWORLD_EVENT_INJECTION_PATTERN,
             // where the event data for the randomized prize will be injected.
-            allLocations.Add(new PrizeLocation("mech rider 3 (new item)", 0x4a4, 0, new string[] { }, new string[] { "in a forgotten land", "in a hard to reach spot", "in a late-game area" }, grandPalaceDependencies.ToArray(), 0.1));
+            allLocations.Add(new PrizeLocation("mech rider 3 (new item)", 0x4a4, 0, new string[] { }, new string[] { "in a forgotten land", "in a hard to reach spot", "in a late-game area" }, grandPalaceBossDependencies.ToArray(), 0.1));
             if (goal == OpenWorldGoalProcessor.GOAL_MANABEAST)
             {
                 if (fastManaFort)
                 {
-                    allLocations.Add(new PrizeLocation("buffy (new item)", 0x422, 0, new string[] { }, new string[] { "in the Mana Fortress", "in a late-game area" }, new string[] { "whip", "sword" }, 0.2));
-                    allLocations.Add(new PrizeLocation("dread slime (new item)", 0x425, 0, new string[] { }, new string[] { "in the Mana Fortress", "in a late-game area" }, new string[] { "whip", "sword" }, 0.2));
+                    allLocations.Add(new PrizeLocation("buffy (new item)", 0x422, 0, new string[] { }, new string[] { "in the Mana Fortress", "in a late-game area" }, new string[] { "whip", DEPENDENCY_CUTTING_WEAPON }, 0.2));
+                    allLocations.Add(new PrizeLocation("dread slime (new item)", 0x425, 0, new string[] { }, new string[] { "in the Mana Fortress", "in a late-game area" }, new string[] { "whip", DEPENDENCY_CUTTING_WEAPON }, 0.2));
                 }
                 else
                 {
@@ -158,12 +160,12 @@ namespace SoMRandomizer.processing.openworld.randomization
                 allLocations.Add(new PrizeLocation("shade spells", 0x586, 0, new string[] { }, new string[] { "in the mountains", "at a Mana seed pedestal", "where a Mana seed should be", "in a late-game area" }, new string[] { "axe", "whip" }, 0.4));
                 allLocations.Add(new PrizeLocation("shade seed", 0x586, 1, new string[] { }, new string[] { "in the mountains", "at a Mana seed pedestal", "where a Mana seed should be", "in a late-game area" }, new string[] { "axe", "whip" }, 0.4));
             }
-            allLocations.Add(new PrizeLocation("thunder gigas (new item)", 0x5f5, 0, new string[] { }, new string[] { "in a volcano", "beyond the Pure Lands bushes", "in a late-game area" }, new string[] { "sword" }, 0.4)); // or axe?
-            allLocations.Add(new PrizeLocation("red dragon (new item)", 0x5f3, 0, new string[] { }, new string[] { "in a volcano", "beyond the Pure Lands bushes", "in a late-game area" }, new string[] { "sword" }, 0.4));
-            allLocations.Add(new PrizeLocation("blue dragon (new item)", 0x5f7, 0, new string[] { }, new string[] { "in a volcano", "beyond the Pure Lands bushes", "in a late-game area" }, new string[] { "sword" }, 0.4));
+            allLocations.Add(new PrizeLocation("thunder gigas (new item)", 0x5f5, 0, new string[] { }, new string[] { "in a volcano", "beyond the Pure Lands bushes", "in a late-game area" }, new string[] { DEPENDENCY_CUTTING_WEAPON }, 0.4));
+            allLocations.Add(new PrizeLocation("red dragon (new item)", 0x5f3, 0, new string[] { }, new string[] { "in a volcano", "beyond the Pure Lands bushes", "in a late-game area" }, new string[] { DEPENDENCY_CUTTING_WEAPON }, 0.4));
+            allLocations.Add(new PrizeLocation("blue dragon (new item)", 0x5f7, 0, new string[] { }, new string[] { "in a volcano", "beyond the Pure Lands bushes", "in a late-game area" }, new string[] { DEPENDENCY_CUTTING_WEAPON }, 0.4));
             if (goal == OpenWorldGoalProcessor.GOAL_MANABEAST)
             {
-                allLocations.Add(new PrizeLocation("mana tree (new item)", 0x5f8, 0, new string[] { }, new string[] { "in a volcano", "at the Mana Tree", "in a late-game area", "in a hard to reach spot" }, new string[] { "sword" }, 0.3));
+                allLocations.Add(new PrizeLocation("mana tree (new item)", 0x5f8, 0, new string[] { }, new string[] { "in a volcano", "at the Mana Tree", "in a late-game area", "in a hard to reach spot" }, new string[] { DEPENDENCY_CUTTING_WEAPON }, 0.3));
             }
 
             List<string> mfHints = new string[] { "in the Upper Land", "in a cave", "in a mid-game area" }.ToList();
@@ -226,7 +228,7 @@ namespace SoMRandomizer.processing.openworld.randomization
             if (flammieDrumInLogic)
             {
                 // axe to walk through the cave
-                allLocations.Add(new PrizeLocation("matango inn javelin orb chest", MAPNUM_MATANGO_INTERIOR_CHEST, 0, 0x692, 0, new string[] { }, new string[] { "in the Upper Land", "in a chest", "in a town", "in a mid-game area" }, new string[] { "axe" }, 2.0));
+                allLocations.Add(new PrizeLocation("matango inn javelin orb chest", MAPNUM_MATANGO_INTERIOR_CHEST, 0, 0x692, 0, new string[] { }, new string[] { "in the Upper Land", "in a chest", "in a town", "in a mid-game area" }, new string[] { DEPENDENCY_MATANGO_ENTRY }, 2.0));
             }
             else
             {
@@ -279,21 +281,19 @@ namespace SoMRandomizer.processing.openworld.randomization
             if (flammieDrumInLogic)
             {
                 // we can repurpose 0x532 here which is the truffle NTC roof dialogue
-                allLocations.Add(new PrizeLocation("sword pedestal", 0x532, 0, new string[] { }, new string[] { "in an early-game area", "in the rabite forest" }, new string[] { "sword" }, 0.8));
+                allLocations.Add(new PrizeLocation("sword pedestal", 0x532, 0, new string[] { }, new string[] { "in an early-game area", "in the rabite forest" }, new string[] { DEPENDENCY_CUTTING_WEAPON }, 0.8));
             }
             return allLocations;
         }
 
-        public static void populateDependencies(RandoSettings settings, RandoContext context, List<string> grandPalaceDependencies, List<string> manafortDependencies)
+        public static void populateDependencies(RandoSettings settings, RandoContext context, List<string> grandPalaceBossDependencies, List<string> manafortDependencies)
         {
             // based on which characters, spells, and spell orbs are included, determine dependencies needed to complete the grand palace
             bool randomizeGrandPalace = settings.getBool(OpenWorldSettings.PROPERTYNAME_RANDOMIZE_GRANDPALACE_ELEMENTS);
             bool girlSpellsExist = context.workingData.getBool(OpenWorldClassSelection.GIRL_MAGIC_EXISTS);
             bool spriteSpellsExist = context.workingData.getBool(OpenWorldClassSelection.SPRITE_MAGIC_EXISTS);
-            grandPalaceDependencies.Add("whip");
-            grandPalaceDependencies.Add("axe");
-            // unsure why this uses sword instead, but it's been this way for a while
-            manafortDependencies.Add("sword");
+            grandPalaceBossDependencies.Add("whip");
+            manafortDependencies.Add(DEPENDENCY_CUTTING_WEAPON);
             manafortDependencies.Add("whip");
             if (randomizeGrandPalace)
             {
@@ -322,9 +322,9 @@ namespace SoMRandomizer.processing.openworld.randomization
                             string item = elementNames[eleValue];
                             if (item != "no")
                             {
-                                if (!grandPalaceDependencies.Contains(item))
+                                if (!grandPalaceBossDependencies.Contains(item))
                                 {
-                                    grandPalaceDependencies.Add(item);
+                                    grandPalaceBossDependencies.Add(item);
                                     manafortDependencies.Add(item);
                                 }
                                 anyValid = true;
@@ -336,19 +336,19 @@ namespace SoMRandomizer.processing.openworld.randomization
                 {
                     if (girlSpellsExist && spriteSpellsExist)
                     {
-                        grandPalaceDependencies.Add(DEPENDENCY_GIRL_SPELLS);
-                        grandPalaceDependencies.Add(DEPENDENCY_SPRITE_SPELLS);
+                        grandPalaceBossDependencies.Add(DEPENDENCY_GIRL_SPELLS);
+                        grandPalaceBossDependencies.Add(DEPENDENCY_SPRITE_SPELLS);
                         manafortDependencies.Add(DEPENDENCY_GIRL_SPELLS);
                         manafortDependencies.Add(DEPENDENCY_SPRITE_SPELLS);
                     }
                     else if (girlSpellsExist)
                     {
-                        grandPalaceDependencies.Add(DEPENDENCY_GIRL_SPELLS);
+                        grandPalaceBossDependencies.Add(DEPENDENCY_GIRL_SPELLS);
                         manafortDependencies.Add(DEPENDENCY_GIRL_SPELLS);
                     }
                     else if (spriteSpellsExist)
                     {
-                        grandPalaceDependencies.Add(DEPENDENCY_SPRITE_SPELLS);
+                        grandPalaceBossDependencies.Add(DEPENDENCY_SPRITE_SPELLS);
                         manafortDependencies.Add(DEPENDENCY_SPRITE_SPELLS);
                     }
                 }
@@ -357,30 +357,30 @@ namespace SoMRandomizer.processing.openworld.randomization
             {
                 if (girlSpellsExist && spriteSpellsExist)
                 {
-                    grandPalaceDependencies.AddRange(new string[] { "gnome spells", "undine spells", "salamando spells", "sylphid spells", "lumina spells", "shade spells", "luna spells", });
-                    grandPalaceDependencies.Add("girlCaster");
-                    grandPalaceDependencies.Add("spriteCaster");
+                    grandPalaceBossDependencies.AddRange(new string[] { "gnome spells", "undine spells", "salamando spells", "sylphid spells", "lumina spells", "shade spells", "luna spells", });
+                    grandPalaceBossDependencies.Add("girlCaster");
+                    grandPalaceBossDependencies.Add("spriteCaster");
                     manafortDependencies.AddRange(new string[] { "gnome spells", "undine spells", "salamando spells", "sylphid spells", "lumina spells", "shade spells", "luna spells", });
                     manafortDependencies.Add("girlCaster");
                     manafortDependencies.Add("spriteCaster");
                 }
                 else if (girlSpellsExist)
                 {
-                    grandPalaceDependencies.AddRange(new string[] { "salamando spells", "sylphid spells", "lumina spells", });
-                    grandPalaceDependencies.Add("girlCaster");
+                    grandPalaceBossDependencies.AddRange(new string[] { "salamando spells", "sylphid spells", "lumina spells", });
+                    grandPalaceBossDependencies.Add("girlCaster");
                     manafortDependencies.AddRange(new string[] { "salamando spells", "sylphid spells", "lumina spells", });
                     manafortDependencies.Add("girlCaster");
                 }
                 else if (spriteSpellsExist)
                 {
-                    grandPalaceDependencies.AddRange(new string[] { "gnome spells", "undine spells", "salamando spells", "sylphid spells", "shade spells", "luna spells", });
-                    grandPalaceDependencies.Add("spriteCaster");
+                    grandPalaceBossDependencies.AddRange(new string[] { "gnome spells", "undine spells", "salamando spells", "sylphid spells", "shade spells", "luna spells", });
+                    grandPalaceBossDependencies.Add("spriteCaster");
                     manafortDependencies.AddRange(new string[] { "gnome spells", "undine spells", "salamando spells", "sylphid spells", "shade spells", "luna spells", });
                     manafortDependencies.Add("spriteCaster");
                 }
             }
 
-            Logging.log("Grand palace dependencies: " + DataUtil.ListToString(grandPalaceDependencies), "debug");
+            Logging.log("Grand palace dependencies: " + DataUtil.ListToString(grandPalaceBossDependencies), "debug");
         }
     }
 }

--- a/SoMRandomizer/processing/openworld/randomization/OpenWorldSimulator.cs
+++ b/SoMRandomizer/processing/openworld/randomization/OpenWorldSimulator.cs
@@ -180,6 +180,20 @@ namespace SoMRandomizer.processing.openworld.randomization
                                         haveThisReq = true;
                                     }
                                 }
+                            } 
+                            else if (req == OpenWorldLocations.DEPENDENCY_CUTTING_WEAPON)
+                            {
+                                if (gottenPrizeNames.Contains("axe") || gottenPrizeNames.Contains("sword"))
+                                {
+                                    haveThisReq = true;
+                                }
+                            }
+                            else if (req == OpenWorldLocations.DEPENDENCY_MATANGO_ENTRY)
+                            {
+                                if (gottenPrizeNames.Contains("axe") || gottenPrizeNames.Contains("flammie drum"))
+                                {
+                                    haveThisReq = true;
+                                }
                             }
                             else
                             {

--- a/SoMRandomizer/processing/openworld/randomization/OpenWorldSpoilers.cs
+++ b/SoMRandomizer/processing/openworld/randomization/OpenWorldSpoilers.cs
@@ -26,7 +26,7 @@ namespace SoMRandomizer.processing.openworld.randomization
                     if (simulationResult.collectionCycles[cycleNum].Contains(prizeLocation.locationName))
                     {
                         PrizeItem thisPrize = prizePlacements[prizeLocation];
-                        Logging.log("  " + prizeLocation.locationName + " -> " + prizePlacements[prizeLocation].prizeName
+                        Logging.log("    " + prizeLocation.locationName + " -> " + prizePlacements[prizeLocation].prizeName
                             + " [event 0x" + prizeLocation.eventNum.ToString("X")
                             + "] [flag 0x" + thisPrize.gotItemEventFlag.ToString("X") + "]", "spoiler");
                         allLocationsLeft.Remove(prizeLocation);
@@ -68,7 +68,7 @@ namespace SoMRandomizer.processing.openworld.randomization
                     if (simulationResult.collectionCycles[cycleNum].Contains(prizeLocation.locationName))
                     {
                         PrizeItem thisPrize = prizePlacements[prizeLocation];
-                        Logging.log("  " + prizeLocation.locationName + " -> " + prizePlacements[prizeLocation].prizeName 
+                        Logging.log("    " + prizeLocation.locationName + " -> " + prizePlacements[prizeLocation].prizeName 
                             + " [event 0x" + prizeLocation.eventNum.ToString("X") 
                             + "] [flag 0x" + thisPrize.gotItemEventFlag.ToString("X") + "]", "spoiler");
                         allLocationsLeft.Remove(prizeLocation);


### PR DESCRIPTION
- Add `DEPENDENCY_CUTTING_WEAPON` to properly check for any cutting weapon on
  - the 2nd half of pure land
  - sword pedestal
  - mana fortress
- Add `DEPENDENCY_MATANGO_ENTRY` to properly check access on matango inn with flammie drum in logic (closes #67)
- Remove mech rider 3 needing axe
- Rename `grandPalaceDependencies` to `grandPalaceBossDependencies` in `populateDependencies` to better reflect usage
- Change indentation for simulation logging to easier see the start of a cycle

Tested on these plando that didn't work before:
- `version=1.44 mode=open opFlammieDrumInLogic=yes plandoSettings=p_Matango-Inn-Chest:Axe;`
- `version=1.44 mode=open opFlammieDrumInLogic=yes plandoSettings=p_Mech-Rider-3:Axe;`
- `version=1.44 mode=open opFlammieDrumInLogic=yes plandoSettings=p_Buffy:Sword;P_boyWeapon:Axe;`
- `version=1.44 mode=open opFlammieDrumInLogic=yes plandoSettings=p_Thunder-Gigas:Sword;P_boyWeapon:Axe;`

Example of logging change:
```
17:26:57 - [spoiler] Open world spoilers:
17:26:57 - [spoiler] [Checks]
17:26:57 - [spoiler]   Collection cycle:0
17:26:57 - [spoiler]     luka item 1 (spear) -> salamando spells [event 0x132] [flag 0xAA]
17:26:57 - [spoiler]     luka item 2 (undine seed) -> luna spells [event 0x132] [flag 0xAE]
```