### PR TITLE
Fix applying plando settings string

### DIFF
--- a/SoMRandomizer/forms/MainForm.cs
+++ b/SoMRandomizer/forms/MainForm.cs
@@ -812,6 +812,10 @@ namespace SoMRandomizer.forms
         {
             // plando button
             plandoForm.Show();
+            if (plandoForm.WindowState == FormWindowState.Minimized)
+            {
+                plandoForm.WindowState = FormWindowState.Normal;
+            }
         }
     }
 }

--- a/SoMRandomizer/forms/PlandoForm.cs
+++ b/SoMRandomizer/forms/PlandoForm.cs
@@ -752,7 +752,7 @@ namespace SoMRandomizer.forms
                             }
                             else if(kvKey.StartsWith(KEY_PREFIX_NONPRIZE))
                             {
-                                string keyName = propertyToDisplay(kvKey);
+                                string keyName = KEY_PREFIX_NONPRIZE + propertyToDisplay(kvKey);
                                 string valueName = propertyToDisplay(kvValue);
                                 if (orbButtonPropertyNames.ContainsKey(keyName))
                                 {


### PR DESCRIPTION
- Fix applying non-prize plando options when pasting settings string
- Also un-minimize plando window on plando button click to avoid confusion

closes #68 

Tested with settings
`version=1.44 mode=open plandoSettings=P_earthPalaceOrbEle:Gnome;P_boyWeapon:Glove;P_mantisAnt:Tropicallo;P_mantisAntEle:Gnome;`