### PR TITLE
race mode option

### DIFF
--- a/SoMRandomizer/config/settings/CommonSettings.cs
+++ b/SoMRandomizer/config/settings/CommonSettings.cs
@@ -75,6 +75,7 @@ namespace SoMRandomizer.config.settings
         public const string PROPERTYNAME_CANDY_HEALOUTS = "candyHealouts";
         public const string PROPERTYNAME_MAGIC_ROPE_DEATH_FIX = "magicRopeDeathFix";
         public const string PROPERTYNAME_SPOILER_LOG = "spoilerLog";
+        public const string PROPERTYNAME_RACE_MODE = "raceMode";
 
         // used by MainForm and CharacterPaletteRandomizer to coordinate custom colors for characters
         public const string PROPERTYNAME_PREFIX_CUSTOM_CHARACTER_COLORS = "CustomCharColor";
@@ -142,6 +143,7 @@ namespace SoMRandomizer.config.settings
             setInitial(PROPERTYNAME_CANDY_HEALOUTS, true); // healing consumables can be used on still-alive 0 hp character
             setInitial(PROPERTYNAME_MAGIC_ROPE_DEATH_FIX, true); // fix invulnerability when using magic rope
             setInitial(PROPERTYNAME_SPOILER_LOG, true); // generate spoiler log
+            setInitial(PROPERTYNAME_RACE_MODE, false); // race mode
             setInitial(PROPERTYNAME_TEST_ONLY, false); // for automated tests; changes how we log
 
             // enumerations

--- a/SoMRandomizer/forms/MainForm_UiOptionsInitialization.cs
+++ b/SoMRandomizer/forms/MainForm_UiOptionsInitialization.cs
@@ -97,6 +97,7 @@ namespace SoMRandomizer.forms
             // randomizations
             propertyManager.makeBooleanValueProperty("generalRandomizations", CommonSettings.PROPERTYNAME_BOSS_ELEMENT_RANDO, "Randomize Boss Elements", "Randomize defense element, color, and spells cast by most bosses.  This is still a work in progress!", commonSettings);
             propertyManager.makeBooleanValueProperty("generalRandomizations", CommonSettings.PROPERTYNAME_SPOILER_LOG, "Spoiler log", "Generate a spoiler log for the seed, with the same name as the normal log + _SPOILER.", commonSettings);
+            propertyManager.makeBooleanValueProperty("generalRandomizations", CommonSettings.PROPERTYNAME_RACE_MODE, "Race mode", "Produces different game/hash on the same seed that only match with other players on race mode and also turns off spoiler log.", commonSettings);
             // stupid stuff
             propertyManager.makeBooleanValueProperty("generalStupid", CommonSettings.PROPERTYNAME_OHKO, "One-hit KO", "Drops your HP to 1 and defense to zero.  Why would you want this?", commonSettings);
             propertyManager.makeBooleanValueProperty("generalStupid", CommonSettings.PROPERTYNAME_WALK_THROUGH_WALLS, "Walk through walls", "Well, go on.  See what's in that unreachable door in North Town.", commonSettings);

--- a/SoMRandomizer/processing/common/RomGenerator.cs
+++ b/SoMRandomizer/processing/common/RomGenerator.cs
@@ -313,6 +313,14 @@ namespace SoMRandomizer.processing.common
             {
                 filenameSeed = filenameSeed.Replace(c, '_');
             }
+
+            if (settings.getBool(CommonSettings.PROPERTYNAME_RACE_MODE))
+            {
+                // advance randomness state up to 8 times.
+                // no clue if this is needed, once might be fine as well
+                int times = context.randomFunctional.Next(8);
+                for (; times > 0; times--) context.randomFunctional.Next();
+            }
             Logging.ClearLoggers();
             if (settings.getBool(CommonSettings.PROPERTYNAME_TEST_ONLY))
             {
@@ -323,7 +331,7 @@ namespace SoMRandomizer.processing.common
             else
             {
                 fileLogger = new FileLogger("./log_" + filenameSeed + ".txt");
-                if (settings.getBool(CommonSettings.PROPERTYNAME_SPOILER_LOG))
+                if (settings.getBool(CommonSettings.PROPERTYNAME_SPOILER_LOG) && !settings.getBool(CommonSettings.PROPERTYNAME_RACE_MODE))
                 {
                     fileLoggerSpoiler = new FileLogger("./log_" + filenameSeed + "_SPOILER.txt");
                 }

--- a/SoMRandomizer/processing/hacks/openworld/TitleMenuSeedHashDisplay.cs
+++ b/SoMRandomizer/processing/hacks/openworld/TitleMenuSeedHashDisplay.cs
@@ -30,7 +30,14 @@ namespace SoMRandomizer.processing.hacks.openworld
                 hash <<= 4;
                 hash |= (r.Next() % 16);
             }
-            string hashString = hash.ToString("X").ToUpper();
+
+            string hashString = "";
+            if (settings.getBool(CommonSettings.PROPERTYNAME_RACE_MODE))
+            {
+                hashString += "r";
+            }
+            hashString += hash.ToString("X").ToUpper();
+
             string seedShortened = seed;
             if (seedShortened.Length > 20)
             {


### PR DESCRIPTION
advances randomFunctional state to generate a different game/hash without spoiler log for a seed, so people cannot easily cheat by generating with a spoiler log.

also appends a small "r" at the start of hash display to indicate race mode is on.