### PR TITLE
Hint Refactor

### DIFF
--- a/SoMRandomizer/processing/common/ElementSwaps.cs
+++ b/SoMRandomizer/processing/common/ElementSwaps.cs
@@ -279,29 +279,7 @@ namespace SoMRandomizer.processing
             // x86->x355 = shade
             // x87->x356 = luna
             // x88->x357 = dryad
-            List<byte> orbElementsAvailable = new List<byte>();
-            if(spriteExists)
-            {
-                orbElementsAvailable.Add(0x81);
-                orbElementsAvailable.Add(0x82);
-                orbElementsAvailable.Add(0x83);
-                orbElementsAvailable.Add(0x85);
-                orbElementsAvailable.Add(0x86);
-                orbElementsAvailable.Add(0x87);
-                orbElementsAvailable.Add(0x88);
-            }
-            if (girlExists)
-            {
-                if (!orbElementsAvailable.Contains(0x83))
-                {
-                    orbElementsAvailable.Add(0x83); // sala
-                }
-                orbElementsAvailable.Add(0x84); // lumina
-                if (!orbElementsAvailable.Contains(0x85))
-                {
-                    orbElementsAvailable.Add(0x85); // sylphid
-                }
-            }
+            List<byte> orbElementsAvailable = GetValidOrbElements(girlExists, spriteExists);
 
             // boy only - remove these switches in event modifier and just set them all to none
             if(orbElementsAvailable.Count == 0)
@@ -665,6 +643,33 @@ namespace SoMRandomizer.processing
                     rom[mapObjOffset + 1] |= 0x80;
                 }
             }
+        }
+
+        public static List<byte> GetValidOrbElements(bool girlExists, bool spriteExists)
+        {
+            List<byte> orbElementsAvailable = new List<byte>();
+            if(spriteExists)
+            {
+                // everything but lumina
+                orbElementsAvailable.Add(0x81); 
+                orbElementsAvailable.Add(0x82);
+                orbElementsAvailable.Add(0x83);
+                orbElementsAvailable.Add(0x85);
+                orbElementsAvailable.Add(0x86);
+                orbElementsAvailable.Add(0x87);
+                orbElementsAvailable.Add(0x88);
+            }
+            if (girlExists)
+            {
+                orbElementsAvailable.Add(0x84); // lumina
+                if (!spriteExists)
+                {
+                    orbElementsAvailable.Add(0x83); // sala
+                    orbElementsAvailable.Add(0x85); // sylphid
+                }
+            }
+
+            return orbElementsAvailable;
         }
     }
 }

--- a/SoMRandomizer/processing/openworld/randomization/OpenWorldHints.cs
+++ b/SoMRandomizer/processing/openworld/randomization/OpenWorldHints.cs
@@ -234,7 +234,6 @@ namespace SoMRandomizer.processing.openworld.randomization
             }
 
             List<OpenWorldSpecialHintTypes> remainingSpecialHints = new List<OpenWorldSpecialHintTypes>{OpenWorldSpecialHintTypes.MECH_RIDER_3_PRICE};
-            // ToDo: is this even needed?
             if (hasItemAtLocation(itemPlacements, "fire seed"))
             {
                 remainingSpecialHints.Add(OpenWorldSpecialHintTypes.FIRE_PLACE_FINAL_PRICE);
@@ -247,10 +246,10 @@ namespace SoMRandomizer.processing.openworld.randomization
 
             foreach (int hintEvent in hintEvents)
             {
-                /* Current changes for rolling hints
+                /* Current chances for rolling hints
                  * useful hint: 80%
                  * useless hint: 20%
-                 * special hint: useful hint * 20% = 16%
+                 * special hint: useful hint * 20% = 16% (max 3)
                  * not special hint: useful hint * 80% = 64%
                  * gp hint | more gp hints: not special hint * 33.3…% = 21.3…%
                  * gp hint | not more gp hints: not special hint * 20% = 12.8%
@@ -259,11 +258,12 @@ namespace SoMRandomizer.processing.openworld.randomization
                  */
                 bool usefulHint = !suppressHints && r.Next(100) < 80;
                 // normal, useful hint
+                // 80%
                 if (usefulHint)
                 {
                     string hintPhrase;
                     // a few specific ones
-                    // 80%, max. 3
+                    // 20%, max. 3
                     bool specialHint = remainingSpecialHints.Count > 0 && r.Next(5) == 0;
                     if (specialHint)
                     {
@@ -313,13 +313,11 @@ namespace SoMRandomizer.processing.openworld.randomization
                     else
                     {
                         // treasure location
-                        // ToDo: should this be change to always just pick any random location and not have it prefer key items? what to we do with allowMissedItems then?
                         hintPhrase = hintPhrases[r.Next() % hintPhrases.Length];
                         List<PrizeLocation> keys = itemPlacements.Keys.ToList();
                         PrizeLocation location = keys[r.Next() % keys.Count];
                         string prize = itemPlacements[location].prizeName;
                         int i = 0; // safety
-                        // ToDo: decide if MRT should skip this
                         if (prize.Contains("seed"))
                         {
                             // reroll once, these are less useful
@@ -348,6 +346,7 @@ namespace SoMRandomizer.processing.openworld.randomization
                 else
                 {
                     // mostly useless hint
+                    // 20%
                     string hintPhrase = dumbHints[r.Next() % dumbHints.Length];
                     addHintEvent(context, hintPhrase, hintEvent, "useless");
                 }

--- a/SoMRandomizer/processing/openworld/randomization/OpenWorldLocations.cs
+++ b/SoMRandomizer/processing/openworld/randomization/OpenWorldLocations.cs
@@ -85,14 +85,14 @@ namespace SoMRandomizer.processing.openworld.randomization
                 allLocations.Add(new PrizeLocation("gnome item 2 (seed)", 0x22e, 1, new string[] { }, gnomeHints.ToArray(), new string[] { _earthPalaceElement + " spells", "whip" }, 0.5));
             }
 
-            List<string> lunaHints = new string[] { "in a strange place", "at a Mana seed pedestal", "where a Mana seed should be", "in a late-game area" }.ToList();
+            List<string> lunaHints = new List<string> { "in a strange place", "at a Mana seed pedestal", "where a Mana seed should be", "in a late-game area" };
             if (anySpellTriggers)
             {
                 string lp = _lunaPalaceElement == "undine" ? "an " + _lunaPalaceElement : "a " + _lunaPalaceElement;
                 lunaHints.Add("behind " + lp + " orb");
             }
 
-            List<string> fp3Hints = new string[] { "in a warm place", "in a hard to reach spot", "at a Mana seed pedestal", "where a Mana seed should be", "in a mid-game area" }.ToList();
+            List<string> fp3Hints = new List<string> { "in a warm place", "in a hard to reach spot", "at a Mana seed pedestal", "where a Mana seed should be", "in a mid-game area" };
             if (anySpellTriggers)
             {
                 string fp1 = _firePalaceElement1 == "undine" ? "an " + _firePalaceElement1 : "a " + _firePalaceElement1;
@@ -116,19 +116,16 @@ namespace SoMRandomizer.processing.openworld.randomization
 
             allLocations.Add(new PrizeLocation("kakkara (moogle belt)", 0x2b2, 0, new string[] { }, new string[] { "in a warm place", "in a town", "at an oasis", "in a mid-game area" }, new string[] { "sea hare tail" }, 0.5));
 
+            List<string> luminaRequirements = new List<string> { "gold tower key" };
             if (restrictiveLogic)
             {
-                allLocations.Add(new PrizeLocation("lumina spells", 0x587, 0, new string[] { }, new string[] { "in a tower", "at a Mana seed pedestal", "where a Mana seed should be", "in a late-game area" }, new string[] { "gold tower key", "light seed" }, 0.5));
-                allLocations.Add(new PrizeLocation("lumina seed", 0x587, 1, new string[] { }, new string[] { "in a tower", "at a Mana seed pedestal", "where a Mana seed should be", "in a late-game area" }, new string[] { "gold tower key", "light seed" }, 0.5));
+                luminaRequirements.Add("light seed");
             }
-            else
-            {
-                allLocations.Add(new PrizeLocation("lumina spells", 0x587, 0, new string[] { }, new string[] { "in a tower", "at a Mana seed pedestal", "where a Mana seed should be", "in a late-game area" }, new string[] { "gold tower key" }, 0.5));
-                allLocations.Add(new PrizeLocation("lumina seed", 0x587, 1, new string[] { }, new string[] { "in a tower", "at a Mana seed pedestal", "where a Mana seed should be", "in a late-game area" }, new string[] { "gold tower key" }, 0.5));
-            }
+            allLocations.Add(new PrizeLocation("lumina spells", 0x587, 0, new string[] { }, new string[] { "in a tower", "at a Mana seed pedestal", "where a Mana seed should be", "in a late-game area", "on an island" }, luminaRequirements.ToArray(), 0.5));
+            allLocations.Add(new PrizeLocation("lumina seed", 0x587, 1, new string[] { }, new string[] { "in a tower", "at a Mana seed pedestal", "where a Mana seed should be", "in a late-game area", "on an island" }, luminaRequirements.ToArray(), 0.5));
 
-            List<string> fp1Hints = new string[] { "in a warm place", "in a chest", "in a mid-game area" }.ToList();
-            List<string> fp2Hints = new string[] { "in a warm place", "in a chest", "in a mid-game area" }.ToList();
+            List<string> fp1Hints = new List<string> { "in a warm place", "in a chest", "in a mid-game area" };
+            List<string> fp2Hints = new List<string> { "in a warm place", "in a chest", "in a mid-game area" };
             if (anySpellTriggers)
             {
                 string fp1 = _firePalaceElement1 == "undine" ? "an " + _firePalaceElement1 : "a " + _firePalaceElement1;
@@ -137,18 +134,18 @@ namespace SoMRandomizer.processing.openworld.randomization
                 fp2Hints.Add("behind " + fp1 + " orb and " + fp2 + " orb");
             }
 
-            allLocations.Add(new PrizeLocation("chest next to whip chest", 0x688, 0, new string[] { }, new string[] { "at the witch's castle", "in a chest", "in an early-game area" }, new string[] { DEPENDENCY_ELINEE_ENTRY }, 0.6));
+            allLocations.Add(new PrizeLocation("chest next to whip chest", 0x688, 0, new string[] { }, new string[] { "at the witch's castle", "in a chest", "in an early-game area", "in a castle" }, new string[] { DEPENDENCY_ELINEE_ENTRY }, 0.6));
             // orb chests
             allLocations.Add(new PrizeLocation("shade palace glove orb chest", MAPNUM_SHADEPALACE_INTERIOR_E, 2, 0x672, 0, new string[] { }, new string[] { "in the mountains", "in a chest", "in a late-game area" }, new string[] { "axe" }, 0.7));
             allLocations.Add(new PrizeLocation("sunken continent sword orb chest", MAPNUM_GRANDPALACE_INTERIOR_D, 12, 0x675, 0, new string[] { }, new string[] { "in a forgotten land", "in a chest", "in a late-game area" }, new string[] { "whip", }, 0.3));
-            allLocations.Add(new PrizeLocation("lumina tower axe orb chest", MAPNUM_LUMINATOWER_2F, 0, 0x677, 0, new string[] { }, new string[] { "in a tower", "in a chest", "in a late-game area" }, new string[] { "gold tower key" }, 0.5));
+            allLocations.Add(new PrizeLocation("lumina tower axe orb chest", MAPNUM_LUMINATOWER_2F, 0, 0x677, 0, new string[] { }, new string[] { "in a tower", "in a chest", "in a late-game area", "on an island" }, new string[] { "gold tower key" }, 0.5));
             allLocations.Add(new PrizeLocation("fire palace axe orb chest", MAPNUM_FIREPALACE_F, 0, 0x678, 0, new string[] { }, fp2Hints.ToArray(), new string[] { _firePalaceElement1 + " spells", _firePalaceElement2 + " spells", }, 0.3));
-            allLocations.Add(new PrizeLocation("lumina tower spear orb chest", MAPNUM_LUMINATOWER_1F, 0, 0x67b, 0, new string[] { }, new string[] { "in a tower", "in a chest", "in a late-game area" }, new string[] { "gold tower key" }, 0.5));
-            allLocations.Add(new PrizeLocation("sunken continent boomerang orb chest", MAPNUM_UNDERSEA_AXE_ROOM_A, 1, 0x691, 0, new string[] { }, new string[] { "in a forgotten land", "in a chest", "in a late-game area" }, new string[] { "axe" }, 0.6));
+            allLocations.Add(new PrizeLocation("lumina tower spear orb chest", MAPNUM_LUMINATOWER_1F, 0, 0x67b, 0, new string[] { }, new string[] { "in a tower", "in a chest", "in a late-game area", "on an island" }, new string[] { "gold tower key" }, 0.5));
+            allLocations.Add(new PrizeLocation("sunken continent boomerang orb chest", MAPNUM_UNDERSEA_AXE_ROOM_A, 1, 0x691, 0, new string[] { }, new string[] { "in a forgotten land", "in a chest", "in a late-game area", "under the sea" }, new string[] { "axe" }, 0.6));
             allLocations.Add(new PrizeLocation("fire palace chest 1", MAPNUM_FIREPALACE_C, 0, 0x68a, 0, new string[] { }, fp1Hints.ToArray(), new string[] { _firePalaceElement1 + " spells", }, 0.4)); // past first orb
             allLocations.Add(new PrizeLocation("fire palace chest 2", MAPNUM_FIREPALACE_G, 1, 0x68b, 0, new string[] { }, fp2Hints.ToArray(), new string[] { _firePalaceElement1 + " spells", _firePalaceElement2 + " spells", }, 0.3)); // past first two orbs
 
-            allLocations.Add(new PrizeLocation("santa (new item)", 0x66d, 0, new string[] { }, new string[] { "in a cold place", "under the Christmas tree", "in a mid-game area" }, new string[] { "whip" }, 0.5));
+            allLocations.Add(new PrizeLocation("santa (new item)", 0x66d, 0, new string[] { }, new string[] { "in a cold place", "under the Christmas tree", "in a mid-game area", "in a castle" }, new string[] { "whip" }, 0.5));
 
             if (restrictiveLogic)
             {
@@ -165,7 +162,7 @@ namespace SoMRandomizer.processing.openworld.randomization
             allLocations.Add(new PrizeLocation("blue dragon (new item)", 0x5f7, 0, new string[] { }, new string[] { "in a volcano", "beyond the Pure Lands bushes", "in a late-game area" }, new string[] { DEPENDENCY_CUTTING_WEAPON }, 0.4));
             if (goal == OpenWorldGoalProcessor.GOAL_MANABEAST)
             {
-                allLocations.Add(new PrizeLocation("mana tree (new item)", 0x5f8, 0, new string[] { }, new string[] { "in a volcano", "at the Mana Tree", "in a late-game area", "in a hard to reach spot" }, new string[] { DEPENDENCY_CUTTING_WEAPON }, 0.3));
+                allLocations.Add(new PrizeLocation("mana tree (new item)", 0x5f8, 0, new string[] { }, new string[] { "in a volcano", "at the Mana Tree", "in a late-game area", "in a hard to reach spot", "beyond the Pure Lands bushes" }, new string[] { DEPENDENCY_CUTTING_WEAPON }, 0.3));
             }
 
             List<string> mfHints = new string[] { "in the Upper Land", "in a cave", "in a mid-game area" }.ToList();
@@ -186,7 +183,7 @@ namespace SoMRandomizer.processing.openworld.randomization
             }
             allLocations.Add(new PrizeLocation("jehk", 0x4e5, 0, new string[] { }, new string[] { "in the mountains", "in a cave", "in a late-game area" }, new string[] { "axe", "whip" }, 0.3));
             allLocations.Add(new PrizeLocation("hydra (new item)", 0x59b, 0, new string[] { }, new string[] { "in a forgotten land", "under the sea", "in a late-game area" }, new string[] { "axe" }, 0.5));
-            allLocations.Add(new PrizeLocation("kettlekin (new item)", 0x4ca, 0, new string[] { }, new string[] { "in a forgotten land", "under the sea", "in a late-game area" }, new string[] { "axe" }, 0.4));
+            allLocations.Add(new PrizeLocation("kettlekin (new item)", 0x4ca, 0, new string[] { }, new string[] { "in a forgotten land", "under the sea", "in a late-game area", "in a hard to reach spot" }, new string[] { "axe" }, 0.4));
             allLocations.Add(new PrizeLocation("shade palace chest", MAPNUM_SHADEPALACE_INTERIOR_B, 0, 0x68e, 0, new string[] { }, new string[] { "in the mountains", "in a chest", "in a late-game area" }, new string[] { "axe" }, 0.5));
 
             if (restrictiveLogic)
@@ -205,26 +202,26 @@ namespace SoMRandomizer.processing.openworld.randomization
             }
 
             // other chests
-            allLocations.Add(new PrizeLocation("whip chest", 0x689, 0, new string[] { }, new string[] { "at the witch's castle", "in a chest", "in an early-game area" }, new string[] { DEPENDENCY_ELINEE_ENTRY }, 0.6));
+            allLocations.Add(new PrizeLocation("whip chest", 0x689, 0, new string[] { }, new string[] { "at the witch's castle", "in a chest", "in an early-game area", "in a castle" }, new string[] { DEPENDENCY_ELINEE_ENTRY }, 0.6));
             allLocations.Add(new PrizeLocation("moogle village glove orb chest", MAPNUM_UPPERLAND_MOOGLE_VILLAGE, 7, 0x670, 0, new string[] { }, new string[] { "in the Upper Land", "in a chest", "in a town", "in a mid-game area", "at Moogle Village" }, new string[] { }, 3.0));
-            allLocations.Add(new PrizeLocation("ice castle glove orb chest", MAPNUM_ICECASTLE_INTERIOR_E, 0, 0x671, 0, new string[] { }, new string[] { "in a cold place", "in a chest", "in a mid-game area" }, new string[] { }, 1.0));
-            allLocations.Add(new PrizeLocation("pandora sword orb chest", MAPNUM_PANDORA_TREASURE_ROOM, 0, 0x673, 0, new string[] { }, new string[] { "in the Pandora area", "in a chest", "in a town", "in a treasure room", "in an early-game area" }, new string[] { }, 0.8));
-            allLocations.Add(new PrizeLocation("northtown ruins sword orb chest", MAPNUM_NTR_INTERIOR_D, 24, 0x674, 0, new string[] { }, new string[] { "in the Empire", "in a chest", "in a mid-game area" }, new string[] { }, 1.5));
+            allLocations.Add(new PrizeLocation("ice castle glove orb chest", MAPNUM_ICECASTLE_INTERIOR_E, 0, 0x671, 0, new string[] { }, new string[] { "in a cold place", "in a chest", "in a mid-game area", "in a castle" }, new string[] { }, 1.0));
+            allLocations.Add(new PrizeLocation("pandora sword orb chest", MAPNUM_PANDORA_TREASURE_ROOM, 0, 0x673, 0, new string[] { }, new string[] { "in the Pandora area", "in a chest", "in a town", "in a treasure room", "in an early-game area", "in a castle" }, new string[] { }, 0.8));
+            allLocations.Add(new PrizeLocation("northtown ruins sword orb chest", MAPNUM_NTR_INTERIOR_D, 24, 0x674, 0, new string[] { }, new string[] { "in the Empire", "in a chest", "in a mid-game area", "in Northtown", "at Northtown Ruins" }, new string[] { }, 1.5));
             allLocations.Add(new PrizeLocation("moogle village axe orb chest", MAPNUM_UPPERLAND_MOOGLE_VILLAGE, 8, 0x676, 0, new string[] { }, new string[] { "in the Upper Land", "in a chest", "in a town", "in a mid-game area", "at Moogle Village" }, new string[] { }, 3.0));
             allLocations.Add(new PrizeLocation("northtown castle axe orb chest", MAPNUM_NTC_INTERIOR_F, 0, 0x679, 0, new string[] { }, new string[] { "in the Empire", "in a chest", "in a mid-game area", "in Northtown", "in a castle", "at Northtown Castle" }, new string[] { }, 1.0));
             allLocations.Add(new PrizeLocation("northtown ruins spear orb chest", MAPNUM_NTR_ENTRANCE, 8, 0x67a, 0, new string[] { }, new string[] { "in the Empire", "in a chest", "in a mid-game area", "in Northtown", "at Northtown Ruins" }, new string[] { }, 1.5));
-            allLocations.Add(new PrizeLocation("pandora spear orb chest", MAPNUM_PANDORA_TREASURE_ROOM, 1, 0x67c, 0, new string[] { }, new string[] { "in the Pandora area", "in a chest", "in a town", "in a treasure room", "in an early-game area" }, new string[] { }, 0.8));
+            allLocations.Add(new PrizeLocation("pandora spear orb chest", MAPNUM_PANDORA_TREASURE_ROOM, 1, 0x67c, 0, new string[] { }, new string[] { "in the Pandora area", "in a chest", "in a town", "in a treasure room", "in an early-game area", "in a castle" }, new string[] { }, 0.8));
             allLocations.Add(new PrizeLocation("santa spear orb chest", MAPNUM_SANTAHOUSE_INTERIOR, 1, 0x67d, 0, new string[] { }, new string[] { "in a cold place", "in a chest", "in a mid-game area", "in a house" }, new string[] { }, 1.5));
             allLocations.Add(new PrizeLocation("kilroy whip orb chest", MAPNUM_KILROYSHIP_LOWER, 0, 0x68c, 0, new string[] { }, new string[] { "somewhere underground", "in a chest", "in a hole", "in an early-game area" }, new string[] { }, 3.0));
             allLocations.Add(new PrizeLocation("northtown castle whip orb chest", MAPNUM_NTC_INTERIOR_F, 1, 0x68f, 0, new string[] { }, new string[] { "in the Empire", "in a chest", "in a mid-game area", "in Northtown", "in a castle", "at Northtown Castle" }, new string[] { }, 1.0));
             allLocations.Add(new PrizeLocation("northtown ruins bow orb chest", MAPNUM_NTR_ENTRANCE, 7, 0x690, 0, new string[] { }, new string[] { "in the Empire", "in a chest", "in a mid-game area", "in Northtown", "at Northtown Ruins" }, new string[] { }, 1.0));
             allLocations.Add(new PrizeLocation("potos chest", MAPNUM_POTOS_INTERIOR_B, 6, 0x680, 0, new string[] { }, new string[] { "in the Potos area", "in a chest", "in a town", "in an early-game area", "in a house" }, new string[] { }, 3.0));
-            allLocations.Add(new PrizeLocation("pandora chest 1", MAPNUM_PANDORA_TREASURE_ROOM, 2, 0x683, 0, new string[] { }, new string[] { "in the Pandora area", "in a chest", "in a town", "in a treasure room", "in an early-game area" }, new string[] { }, 0.8));
-            allLocations.Add(new PrizeLocation("pandora chest 2", MAPNUM_PANDORA_TREASURE_ROOM, 3, 0x684, 0, new string[] { }, new string[] { "in the Pandora area", "in a chest", "in a town", "in a treasure room", "in an early-game area" }, new string[] { }, 0.8));
-            allLocations.Add(new PrizeLocation("pandora chest 3", MAPNUM_PANDORA_TREASURE_ROOM, 4, 0x685, 0, new string[] { }, new string[] { "in the Pandora area", "in a chest", "in a town", "in a treasure room", "in an early-game area" }, new string[] { }, 0.8));
-            allLocations.Add(new PrizeLocation("pandora chest 4", MAPNUM_PANDORA_TREASURE_ROOM, 5, 0x686, 0, new string[] { }, new string[] { "in the Pandora area", "in a chest", "in a town", "in a treasure room", "in an early-game area" }, new string[] { }, 0.8));
+            allLocations.Add(new PrizeLocation("pandora chest 1", MAPNUM_PANDORA_TREASURE_ROOM, 2, 0x683, 0, new string[] { }, new string[] { "in the Pandora area", "in a chest", "in a town", "in a treasure room", "in an early-game area", "in a castle" }, new string[] { }, 0.8));
+            allLocations.Add(new PrizeLocation("pandora chest 2", MAPNUM_PANDORA_TREASURE_ROOM, 3, 0x684, 0, new string[] { }, new string[] { "in the Pandora area", "in a chest", "in a town", "in a treasure room", "in an early-game area", "in a castle" }, new string[] { }, 0.8));
+            allLocations.Add(new PrizeLocation("pandora chest 3", MAPNUM_PANDORA_TREASURE_ROOM, 4, 0x685, 0, new string[] { }, new string[] { "in the Pandora area", "in a chest", "in a town", "in a treasure room", "in an early-game area", "in a castle" }, new string[] { }, 0.8));
+            allLocations.Add(new PrizeLocation("pandora chest 4", MAPNUM_PANDORA_TREASURE_ROOM, 5, 0x686, 0, new string[] { }, new string[] { "in the Pandora area", "in a chest", "in a town", "in a treasure room", "in an early-game area", "in a castle" }, new string[] { }, 0.8));
             allLocations.Add(new PrizeLocation("magic rope chest", MAPNUM_MAGICROPE, 0, 0x687, 0, new string[] { }, new string[] { "somewhere underground", "in a chest", "in a cave", "in an early-game area" }, new string[] { }, 1.5));
-            allLocations.Add(new PrizeLocation("northtown castle chest", MAPNUM_NTC_INTERIOR_A, 2, 0x68d, 0, new string[] { }, new string[] { "in the Empire", "in a chest", "in a mid-game area" }, new string[] { }, 0.8));
+            allLocations.Add(new PrizeLocation("northtown castle chest", MAPNUM_NTC_INTERIOR_A, 2, 0x68d, 0, new string[] { }, new string[] { "in the Empire", "in a chest", "in a mid-game area", "in Northtown", "in a castle", "at Northtown Castle" }, new string[] { }, 0.8));
             if (flammieDrumInLogic)
             {
                 // axe to walk through the cave
@@ -253,7 +250,7 @@ namespace SoMRandomizer.processing.openworld.randomization
             allLocations.Add(new PrizeLocation("dwarf elder (midge mallet)", 0x366, 0, new string[] { }, new string[] { "somewhere underground", "in a town", "in a cave", "in an early-game area" }, new string[] { }, 3.0));
             allLocations.Add(new PrizeLocation("tropicallo (sprite)", 0x1b9, 0, new string[] { }, new string[] { "somewhere underground", "in a town", "in a cave", "in an early-game area" }, new string[] { }, 1.0));
             allLocations.Add(new PrizeLocation("tropicallo (bow)", 0x1b9, 1, new string[] { }, new string[] { "somewhere underground", "in a town", "in a cave", "in an early-game area" }, new string[] { }, 1.0));
-            allLocations.Add(new PrizeLocation("girl", 0x188, 0, new string[] { }, new string[] { "in the Pandora area", "in a town", "in an early-game area" }, new string[] { }, 2.5));
+            allLocations.Add(new PrizeLocation("girl", 0x188, 0, new string[] { }, new string[] { "in the Pandora area", "in a town", "in an early-game area", "in a castle" }, new string[] { }, 2.5));
             allLocations.Add(new PrizeLocation("starter weapon (main)", 0x103, 0, new string[] { }, new string[] { }, 1.0));
             if (anyCharsAdded)
             {
@@ -268,20 +265,20 @@ namespace SoMRandomizer.processing.openworld.randomization
             allLocations.Add(new PrizeLocation("snow dragon (new item)", 0x5ef, 0, new string[] { }, new string[] { "in a volcano", "before the Pure Lands bushes", "in a late-game area" }, new string[] { }, 0.8));
             // don't need cutting weapon to get here (boss 1)
             allLocations.Add(new PrizeLocation("dragon worm (new item)", 0x5ed, 0, new string[] { }, new string[] { "in a volcano", "before the Pure Lands bushes", "in a late-game area" }, new string[] { }, 0.8)); 
-            allLocations.Add(new PrizeLocation("doom wall", 0x553, 0, new string[] { }, new string[] { "in the Empire", "in a mid-game area" }, new string[] { }, 0.7));
-            allLocations.Add(new PrizeLocation("vampire", 0x559, 0, new string[] { }, new string[] { "in the Empire", "in a mid-game area" }, new string[] { }, 0.6));
-            allLocations.Add(new PrizeLocation("mech rider 2", 0x52f, 0, new string[] { }, new string[] { "in the Empire", "in a mid-game area" }, new string[] { }, 0.6));
+            allLocations.Add(new PrizeLocation("doom wall", 0x553, 0, new string[] { }, new string[] { "in the Empire", "in a mid-game area", "in Northtown", "at Northtown Ruins" }, new string[] { }, 0.7));
+            allLocations.Add(new PrizeLocation("vampire", 0x559, 0, new string[] { }, new string[] { "in the Empire", "in a mid-game area", "in Northtown", "at Northtown Ruins" }, new string[] { }, 0.6));
+            allLocations.Add(new PrizeLocation("mech rider 2", 0x52f, 0, new string[] { }, new string[] { "in the Empire", "in a mid-game area", "in Northtown", "in a castle", "at Northtown Castle" }, new string[] { }, 0.6));
             allLocations.Add(new PrizeLocation("watermelon (new item)", 0x4b4, 0, new string[] { }, new string[] { "in a forgotten land", "in a late-game area" }, new string[] { }, 0.7));
             allLocations.Add(new PrizeLocation("hexas (new item)", 0x4a2, 0, new string[] { }, new string[] { "in a forgotten land", "in a late-game area" }, new string[] { }, 0.7));
             allLocations.Add(new PrizeLocation("wall face (new item)", 0x16e, 0, new string[] { }, new string[] { "in the Pandora area", "in an early-game area" }, new string[] { }, 0.8));
-            allLocations.Add(new PrizeLocation("metal mantis (new item)", 0x527, 0, new string[] { }, new string[] { "in the Empire", "in a mid-game area" }, new string[] { }, 0.8));
-            allLocations.Add(new PrizeLocation("jema at tasnica", 0x2d1, 0, new string[] { }, new string[] { "at Tasnica", "in a town", "in a late-game area" }, new string[] { }, 1.0));
-            allLocations.Add(new PrizeLocation("triple tonpole", 0x66a, 0, new string[] { }, new string[] { "in a cold place", "in a mid-game area" }, new string[] { }, 0.8));
+            allLocations.Add(new PrizeLocation("metal mantis (new item)", 0x527, 0, new string[] { }, new string[] { "in the Empire", "in a mid-game area",  "in Northtown", "in a castle", "at Northtown Castle" }, new string[] { }, 0.8));
+            allLocations.Add(new PrizeLocation("jema at tasnica", 0x2d1, 0, new string[] { }, new string[] { "at Tasnica", "in a town", "in a late-game area", "in a castle" }, new string[] { }, 1.0));
+            allLocations.Add(new PrizeLocation("triple tonpole", 0x66a, 0, new string[] { }, new string[] { "in a cold place", "in a mid-game area", "in a castle", "in a hole" }, new string[] { }, 0.8));
 
             if (flammieDrumInLogic)
             {
                 // we can repurpose 0x532 here which is the truffle NTC roof dialogue
-                allLocations.Add(new PrizeLocation("sword pedestal", 0x532, 0, new string[] { }, new string[] { "in an early-game area", "in the rabite forest" }, new string[] { DEPENDENCY_CUTTING_WEAPON }, 0.8));
+                allLocations.Add(new PrizeLocation("sword pedestal", 0x532, 0, new string[] { }, new string[] { "in an early-game area", "in the rabite forest", "in the Potos area" }, new string[] { DEPENDENCY_CUTTING_WEAPON }, 0.8));
             }
             return allLocations;
         }


### PR DESCRIPTION
This refactors a bunch of stuff around hints:
1. I fixed special hints being somewhat predictable.
2. I added a bunch of extra locations to some hints because
    i. some seem inconsistent to me
    ii. to nerf hints a bit making them a bit more vague

Current changes to "normal" hints:
- in a hard to reach spot
  - kettlekin
- beyond the Pure Lands bushes
  - mana tree
- under the sea
  - sunken continent sword orb chest
- in the Potos area
  - sword pedestal
- at Northtown Castle
  - northtown castle chest
  - mech rider 2
  - metal mantis (new item)
- at Northtown Ruins
  - northtown ruins sword orb chest
  - doom wall
  - vampire
- in Northtown
  - the missing checks from at Northtown Castle (3)
  - the missing checks from at Northtown Ruins (3)
- in a castle
  - all (2) witches castle checks
  - all (3) ice castle checks
  - pandora chests (6)
  - girl
  - the missing checks from at Northtown Castle (3)
  - jema at tasnica
- in a hole
  - triple tonpole
- on an island
  - all gold tower checks (4)

ToDos/TBD:
- [ ] ~~should "normal" hints be refactor to not prefer keyitems but rather pick locations at complete random?~~
- [ ] currently hints for seeds are re-rolled **once** as they are deemed less useful then other keyitems, should this be skipped for MTR?
- [ ] ~~the special hint for fire palace final, checks if that location even is in itemPlacements. Is that even needed?~~
- [ ] should we remove some (all?) of the hints that hint only a few locations?
  - [ ] at Tasnica
  - [ ] in the Rabite forest
  - [ ] under the Christmas tree
  - [ ] at the Mana Tree
  - [ ] in a furnace
  - [ ] at an oasis
  - [ ] in a strange place
  - [ ] in the Mana Fortress
  - [ ] behind a waterfall
  - [ ] at Moggle Village

Other code changes:
- refactor OpenWorldHints code quite a bit
- refactor GetValidOrbElements into a function