### PR TITLE
Fix Min/MaxLevelTabelLoc default not set

### DIFF
--- a/SoMRandomizer/processing/hacks/openworld/MinMaxLevel.cs
+++ b/SoMRandomizer/processing/hacks/openworld/MinMaxLevel.cs
@@ -25,11 +25,11 @@ namespace SoMRandomizer.processing.hacks.openworld
         {
             bool doMinLevel = settings.getBool(OpenWorldSettings.PROPERTYNAME_MIN_ENEMY_LEVELS);
             bool doMaxLevel = settings.getBool(OpenWorldSettings.PROPERTYNAME_MAX_ENEMY_LEVELS);
+            context.workingData.setInt(MINMAXLEVEL_MIN_OFFSET_HIROM, 0);
+            context.workingData.setInt(MINMAXLEVEL_MAX_OFFSET_HIROM, 0);
             if(!doMinLevel && !doMaxLevel)
             {
                 Logging.log("Skipping min/max level; neither setting enabled");
-                context.workingData.setInt(MINMAXLEVEL_MIN_OFFSET_HIROM, 0);
-                context.workingData.setInt(MINMAXLEVEL_MAX_OFFSET_HIROM, 0);
                 return false;
             }
 


### PR DESCRIPTION
default was not set when only 1 of the options was set causing an exception when EnemiesAtYourLevel tries to read the values