### PR TITLE
Fix: manaSeedsRequired now includes max value

### DIFF
--- a/SoMRandomizer/processing/openworld/OpenWorldMtrSeedNumSelection.cs
+++ b/SoMRandomizer/processing/openworld/OpenWorldMtrSeedNumSelection.cs
@@ -38,7 +38,7 @@ namespace SoMRandomizer.processing.openworld
                     min = max;
                 }
                 int diff = max - min;
-                manaSeedsRequired = diff == 0 ? min : ((r.Next() % diff) + min);
+                manaSeedsRequired = diff == 0 ? min : r.Next(min, max + 1);
                 if (manaSeedsRequired < 1)
                 {
                     manaSeedsRequired = 1;


### PR DESCRIPTION
### Summary
This PR fixes a bug where manaSeedsRequired never reaches the max value.

### Fix
- Replaced the modulo-based calculation with r.Next(min, max + 1)

### Related Issue
Fixes #92